### PR TITLE
Moving foundry tests

### DIFF
--- a/test/foundry-tests/Pool.t.sol
+++ b/test/foundry-tests/Pool.t.sol
@@ -2,10 +2,10 @@ pragma solidity ^0.8.13;
 
 import {DSTest} from '../../foundry/testdata/lib/ds-test/src/test.sol';
 import {Cheats} from '../../foundry/testdata/cheats/Cheats.sol';
-import {Pool} from '../libraries/Pool.sol';
-import {Position} from '../libraries/Position.sol';
-import {TickMath} from '../libraries/TickMath.sol';
-import {Tick} from '../libraries/Tick.sol';
+import {Pool} from '../../contracts/libraries/Pool.sol';
+import {Position} from '../../contracts/libraries/Position.sol';
+import {TickMath} from '../../contracts/libraries/TickMath.sol';
+import {Tick} from '../../contracts/libraries/Tick.sol';
 
 contract PoolTest is DSTest {
     using Pool for Pool.State;

--- a/test/foundry-tests/SafeCast.t.sol
+++ b/test/foundry-tests/SafeCast.t.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.8.13;
 
 import {DSTest} from '../../foundry/testdata/lib/ds-test/src/test.sol';
 import {Cheats} from '../../foundry/testdata/cheats/Cheats.sol';
-import {SafeCast} from '../libraries/SafeCast.sol';
+import {SafeCast} from '../../contracts/libraries/SafeCast.sol';
 
 contract SafeCastTest is DSTest {
     Cheats vm = Cheats(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);


### PR DESCRIPTION
Having these files in the main `contracts` folder, and them importing from a submodule was causing an error when using `core-next` as a node module 🤪 