### PR TITLE
feat: use high optimizer runs value

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = 'contracts'
 out = 'foundry-out'
 solc_version = '0.8.13'
-optimizer_runs = 800
+optimizer_runs = 100000
 
 [ci]
 fuzz_runs = 100000

--- a/test/__snapshots__/BitMath.spec.ts.snap
+++ b/test/__snapshots__/BitMath.spec.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BitMath #leastSignificantBit gas cost of max uint128 1`] = `431`;
+exports[`BitMath #leastSignificantBit gas cost of max uint128 1`] = `407`;
 
-exports[`BitMath #leastSignificantBit gas cost of max uint256 1`] = `431`;
+exports[`BitMath #leastSignificantBit gas cost of max uint256 1`] = `407`;
 
-exports[`BitMath #leastSignificantBit gas cost of smaller number 1`] = `429`;
+exports[`BitMath #leastSignificantBit gas cost of smaller number 1`] = `408`;
 
 exports[`BitMath #mostSignificantBit gas cost of max uint128 1`] = `368`;
 

--- a/test/__snapshots__/Hooks.spec.ts.snap
+++ b/test/__snapshots__/Hooks.spec.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`Hooks #shouldCall gas cost of shouldCall 1`] = `7`;
 
-exports[`Hooks #validateHookAddress gas cost of validateHookAddress 1`] = `1443`;
+exports[`Hooks #validateHookAddress gas cost of validateHookAddress 1`] = `1383`;

--- a/test/__snapshots__/Oracle.spec.ts.snap
+++ b/test/__snapshots__/Oracle.spec.ts.snap
@@ -3,43 +3,43 @@
 exports[`Oracle #grow gas for growing by 1 slot when index != cardinality - 1 1`] = `
 Object {
   "calldataByteLength": 36,
-  "gasUsed": 49072,
+  "gasUsed": 49057,
 }
 `;
 
 exports[`Oracle #grow gas for growing by 1 slot when index == cardinality - 1 1`] = `
 Object {
   "calldataByteLength": 36,
-  "gasUsed": 49072,
+  "gasUsed": 49057,
 }
 `;
 
 exports[`Oracle #grow gas for growing by 10 slots when index != cardinality - 1 1`] = `
 Object {
   "calldataByteLength": 36,
-  "gasUsed": 249214,
+  "gasUsed": 249172,
 }
 `;
 
 exports[`Oracle #grow gas for growing by 10 slots when index == cardinality - 1 1`] = `
 Object {
   "calldataByteLength": 36,
-  "gasUsed": 249214,
+  "gasUsed": 249172,
 }
 `;
 
 exports[`Oracle #initialize gas 1`] = `
 Object {
   "calldataByteLength": 100,
-  "gasUsed": 67690,
+  "gasUsed": 67618,
 }
 `;
 
-exports[`Oracle #observe before initialization gas for observe since most recent 1`] = `4615`;
+exports[`Oracle #observe before initialization gas for observe since most recent 1`] = `4537`;
 
-exports[`Oracle #observe before initialization gas for single observation at current time 1`] = `3525`;
+exports[`Oracle #observe before initialization gas for single observation at current time 1`] = `3483`;
 
-exports[`Oracle #observe before initialization gas for single observation at current time counterfactually computed 1`] = `4000`;
+exports[`Oracle #observe before initialization gas for single observation at current time counterfactually computed 1`] = `3922`;
 
 exports[`Oracle #observe initialized with 5 observations with starting time of 5 fetch many values 1`] = `
 Object {
@@ -64,17 +64,17 @@ Object {
 }
 `;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas all of last 20 seconds 1`] = `87289`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas all of last 20 seconds 1`] = `84703`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas between oldest and oldest + 1 1`] = `15571`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas between oldest and oldest + 1 1`] = `15397`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas latest equal 1`] = `3525`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas latest equal 1`] = `3483`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas latest transform 1`] = `4000`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas latest transform 1`] = `3922`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas middle 1`] = `13746`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas middle 1`] = `13572`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas oldest 1`] = `15277`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 5 gas oldest 1`] = `15115`;
 
 exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 fetch many values 1`] = `
 Object {
@@ -99,14 +99,14 @@ Object {
 }
 `;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas all of last 20 seconds 1`] = `87289`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas all of last 20 seconds 1`] = `84703`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas between oldest and oldest + 1 1`] = `15571`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas between oldest and oldest + 1 1`] = `15397`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas latest equal 1`] = `3525`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas latest equal 1`] = `3483`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas latest transform 1`] = `4000`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas latest transform 1`] = `3922`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas middle 1`] = `13746`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas middle 1`] = `13572`;
 
-exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas oldest 1`] = `15277`;
+exports[`Oracle #observe initialized with 5 observations with starting time of 4294967291 gas oldest 1`] = `15115`;

--- a/test/__snapshots__/PoolManager.gas.spec.ts.snap
+++ b/test/__snapshots__/PoolManager.gas.spec.ts.snap
@@ -3,132 +3,132 @@
 exports[`PoolManager gas tests #initialize initialize pool with no hooks and no protocol fee 1`] = `
 Object {
   "calldataByteLength": 196,
-  "gasUsed": 48805,
+  "gasUsed": 48640,
 }
 `;
 
 exports[`PoolManager gas tests #mint above current price add to position existing 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 181129,
+  "gasUsed": 180193,
 }
 `;
 
 exports[`PoolManager gas tests #mint above current price new position mint first in range 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 240670,
+  "gasUsed": 239734,
 }
 `;
 
 exports[`PoolManager gas tests #mint above current price second position in same range 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 181129,
+  "gasUsed": 180193,
 }
 `;
 
 exports[`PoolManager gas tests #mint around current price add to position existing 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 249649,
+  "gasUsed": 248317,
 }
 `;
 
 exports[`PoolManager gas tests #mint around current price new position mint first in range 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 358894,
+  "gasUsed": 357562,
 }
 `;
 
 exports[`PoolManager gas tests #mint around current price second position in same range 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 249649,
+  "gasUsed": 248317,
 }
 `;
 
 exports[`PoolManager gas tests #mint below current price add to position existing 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 181806,
+  "gasUsed": 180865,
 }
 `;
 
 exports[`PoolManager gas tests #mint below current price new position mint first in range 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 305715,
+  "gasUsed": 304774,
 }
 `;
 
 exports[`PoolManager gas tests #mint below current price second position in same range 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 181806,
+  "gasUsed": 180865,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 229688,
+  "gasUsed": 228016,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 first swap in block with no tick movement 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 223794,
+  "gasUsed": 222419,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 248636,
+  "gasUsed": 246613,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 290680,
+  "gasUsed": 287656,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 241674,
+  "gasUsed": 239384,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 229688,
+  "gasUsed": 228016,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 second swap in block with no tick movement 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 223883,
+  "gasUsed": 222510,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 242860,
+  "gasUsed": 241134,
 }
 `;
 
 exports[`PoolManager gas tests #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 284878,
+  "gasUsed": 282156,
 }
 `;

--- a/test/__snapshots__/PoolManager.spec.ts.snap
+++ b/test/__snapshots__/PoolManager.spec.ts.snap
@@ -3,50 +3,50 @@
 exports[`PoolManager #initialize gas cost 1`] = `
 Object {
   "calldataByteLength": 196,
-  "gasUsed": 49105,
+  "gasUsed": 48943,
 }
 `;
 
 exports[`PoolManager #lock gas overhead of no-op lock 1`] = `
 Object {
   "calldataByteLength": 36,
-  "gasUsed": 59780,
+  "gasUsed": 59724,
 }
 `;
 
 exports[`PoolManager #mint gas cost 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 287310,
+  "gasUsed": 286244,
 }
 `;
 
 exports[`PoolManager #mint gas cost with hooks 1`] = `
 Object {
   "calldataByteLength": 260,
-  "gasUsed": 291426,
+  "gasUsed": 290303,
 }
 `;
 
 exports[`PoolManager #swap gas cost 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 84545,
+  "gasUsed": 83744,
 }
 `;
 
 exports[`PoolManager #swap gas cost for swap against liquidity 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 224157,
+  "gasUsed": 222775,
 }
 `;
 
 exports[`PoolManager #swap gas cost with hooks 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 84574,
+  "gasUsed": 83772,
 }
 `;
 
-exports[`PoolManager bytecode size 1`] = `23344`;
+exports[`PoolManager bytecode size 1`] = `29722`;

--- a/test/__snapshots__/SqrtPriceMath.spec.ts.snap
+++ b/test/__snapshots__/SqrtPriceMath.spec.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 1`] = `603`;
+exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 1`] = `540`;
 
-exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 2`] = `483`;
+exports[`SqrtPriceMath #getAmount0Delta gas cost for amount0 where roundUp = true 2`] = `420`;
 
-exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = false 1`] = `483`;
+exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = false 1`] = `420`;
 
-exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = true 1`] = `603`;
+exports[`SqrtPriceMath #getAmount1Delta gas cost for amount0 where roundUp = true 1`] = `540`;
 
-exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = false gas 1`] = `562`;
+exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = false gas 1`] = `490`;
 
-exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = true gas 1`] = `761`;
+exports[`SqrtPriceMath #getNextSqrtPriceFromInput zeroForOne = true gas 1`] = `707`;
 
-exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = false gas 1`] = `859`;
+exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = false gas 1`] = `793`;
 
-exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = true gas 1`] = `492`;
+exports[`SqrtPriceMath #getNextSqrtPriceFromOutput zeroForOne = true gas 1`] = `420`;

--- a/test/__snapshots__/SwapMath.spec.ts.snap
+++ b/test/__snapshots__/SwapMath.spec.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapMath #computeSwapStep gas swap one for zero exact in capped 1`] = `2221`;
+exports[`SwapMath #computeSwapStep gas swap one for zero exact in capped 1`] = `2029`;
 
-exports[`SwapMath #computeSwapStep gas swap one for zero exact in partial 1`] = `3044`;
+exports[`SwapMath #computeSwapStep gas swap one for zero exact in partial 1`] = `2714`;
 
-exports[`SwapMath #computeSwapStep gas swap one for zero exact out capped 1`] = `1968`;
+exports[`SwapMath #computeSwapStep gas swap one for zero exact out capped 1`] = `1803`;
 
-exports[`SwapMath #computeSwapStep gas swap one for zero exact out partial 1`] = `3044`;
+exports[`SwapMath #computeSwapStep gas swap one for zero exact out partial 1`] = `2714`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact in capped 1`] = `2210`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact in capped 1`] = `2021`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact in partial 1`] = `3208`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact in partial 1`] = `2908`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact out capped 1`] = `1957`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact out capped 1`] = `1795`;
 
-exports[`SwapMath #computeSwapStep gas swap zero for one exact out partial 1`] = `3208`;
+exports[`SwapMath #computeSwapStep gas swap zero for one exact out partial 1`] = `2908`;

--- a/test/__snapshots__/Tick.spec.ts.snap
+++ b/test/__snapshots__/Tick.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tick #tickSpacingToMaxLiquidityPerTick gas cost 60 tick spacing 1`] = `128`;
+exports[`Tick #tickSpacingToMaxLiquidityPerTick gas cost 60 tick spacing 1`] = `116`;
 
-exports[`Tick #tickSpacingToMaxLiquidityPerTick gas cost max tick spacing 1`] = `128`;
+exports[`Tick #tickSpacingToMaxLiquidityPerTick gas cost max tick spacing 1`] = `116`;
 
-exports[`Tick #tickSpacingToMaxLiquidityPerTick gas cost min tick spacing 1`] = `128`;
+exports[`Tick #tickSpacingToMaxLiquidityPerTick gas cost min tick spacing 1`] = `116`;

--- a/test/__snapshots__/TickBitmap.spec.ts.snap
+++ b/test/__snapshots__/TickBitmap.spec.ts.snap
@@ -21,14 +21,14 @@ Object {
 }
 `;
 
-exports[`TickBitmap #nextInitializedTickWithinOneWord lte = false gas cost for entire word 1`] = `2572`;
+exports[`TickBitmap #nextInitializedTickWithinOneWord lte = false gas cost for entire word 1`] = `2569`;
 
-exports[`TickBitmap #nextInitializedTickWithinOneWord lte = false gas cost just below boundary 1`] = `2572`;
+exports[`TickBitmap #nextInitializedTickWithinOneWord lte = false gas cost just below boundary 1`] = `2569`;
 
-exports[`TickBitmap #nextInitializedTickWithinOneWord lte = false gas cost on boundary 1`] = `2572`;
+exports[`TickBitmap #nextInitializedTickWithinOneWord lte = false gas cost on boundary 1`] = `2569`;
 
-exports[`TickBitmap #nextInitializedTickWithinOneWord lte = true gas cost for entire word 1`] = `2570`;
+exports[`TickBitmap #nextInitializedTickWithinOneWord lte = true gas cost for entire word 1`] = `2567`;
 
-exports[`TickBitmap #nextInitializedTickWithinOneWord lte = true gas cost just below boundary 1`] = `2880`;
+exports[`TickBitmap #nextInitializedTickWithinOneWord lte = true gas cost just below boundary 1`] = `2877`;
 
-exports[`TickBitmap #nextInitializedTickWithinOneWord lte = true gas cost on boundary 1`] = `2570`;
+exports[`TickBitmap #nextInitializedTickWithinOneWord lte = true gas cost on boundary 1`] = `2567`;

--- a/test/__snapshots__/TickMath.spec.ts.snap
+++ b/test/__snapshots__/TickMath.spec.ts.snap
@@ -56,110 +56,110 @@ exports[`TickMath #getSqrtRatioAtTick tick -738203 gas 1`] = `917`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -738203 result 1`] = `"7409801140451"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 50 gas 1`] = `869`;
+exports[`TickMath #getSqrtRatioAtTick tick 50 gas 1`] = `866`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 50 result 1`] = `"79426470787362580746886972461"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 100 gas 1`] = `869`;
+exports[`TickMath #getSqrtRatioAtTick tick 100 gas 1`] = `866`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 100 result 1`] = `"79625275426524748796330556128"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 250 gas 1`] = `911`;
+exports[`TickMath #getSqrtRatioAtTick tick 250 gas 1`] = `908`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 250 result 1`] = `"80224679980005306637834519095"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 500 gas 1`] = `911`;
+exports[`TickMath #getSqrtRatioAtTick tick 500 gas 1`] = `908`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 500 result 1`] = `"81233731461783161732293370115"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 1000 gas 1`] = `911`;
+exports[`TickMath #getSqrtRatioAtTick tick 1000 gas 1`] = `908`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 1000 result 1`] = `"83290069058676223003182343270"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 2500 gas 1`] = `897`;
+exports[`TickMath #getSqrtRatioAtTick tick 2500 gas 1`] = `894`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 2500 result 1`] = `"89776708723587163891445672585"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 3000 gas 1`] = `925`;
+exports[`TickMath #getSqrtRatioAtTick tick 3000 gas 1`] = `922`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 3000 result 1`] = `"92049301871182272007977902845"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 4000 gas 1`] = `911`;
+exports[`TickMath #getSqrtRatioAtTick tick 4000 gas 1`] = `908`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 4000 result 1`] = `"96768528593268422080558758223"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 5000 gas 1`] = `897`;
+exports[`TickMath #getSqrtRatioAtTick tick 5000 gas 1`] = `894`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 5000 result 1`] = `"101729702841318637793976746270"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 50000 gas 1`] = `911`;
+exports[`TickMath #getSqrtRatioAtTick tick 50000 gas 1`] = `908`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 50000 result 1`] = `"965075977353221155028623082916"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 150000 gas 1`] = `939`;
+exports[`TickMath #getSqrtRatioAtTick tick 150000 gas 1`] = `936`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 150000 result 1`] = `"143194173941309278083010301478497"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 250000 gas 1`] = `925`;
+exports[`TickMath #getSqrtRatioAtTick tick 250000 gas 1`] = `922`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 250000 result 1`] = `"21246587762933397357449903968194344"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 500000 gas 1`] = `925`;
+exports[`TickMath #getSqrtRatioAtTick tick 500000 gas 1`] = `922`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 500000 result 1`] = `"5697689776495288729098254600827762987878"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 738203 gas 1`] = `957`;
+exports[`TickMath #getSqrtRatioAtTick tick 738203 gas 1`] = `954`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 738203 result 1`] = `"847134979253254120489401328389043031315994541"`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 4295128739 gas 1`] = `2365`;
+exports[`TickMath #getTickAtSqrtRatio ratio 4295128739 gas 1`] = `2311`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 4295128739 result 1`] = `-887272`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543 gas 1`] = `2350`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543 gas 1`] = `2296`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543 result 1`] = `-276325`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950 gas 1`] = `2350`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950 gas 1`] = `2296`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950 result 1`] = `-138163`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 9903520314283042199192993792 gas 1`] = `1378`;
+exports[`TickMath #getTickAtSqrtRatio ratio 9903520314283042199192993792 gas 1`] = `1348`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 9903520314283042199192993792 result 1`] = `-41591`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 28011385487393069959365969113 gas 1`] = `2323`;
+exports[`TickMath #getTickAtSqrtRatio ratio 28011385487393069959365969113 gas 1`] = `2269`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 28011385487393069959365969113 result 1`] = `-20796`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 56022770974786139918731938227 gas 1`] = `2309`;
+exports[`TickMath #getTickAtSqrtRatio ratio 56022770974786139918731938227 gas 1`] = `2255`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 56022770974786139918731938227 result 1`] = `-6932`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336 gas 1`] = `2229`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336 gas 1`] = `2175`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336 result 1`] = `0`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 112045541949572279837463876454 gas 1`] = `2349`;
+exports[`TickMath #getTickAtSqrtRatio ratio 112045541949572279837463876454 gas 1`] = `2292`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 112045541949572279837463876454 result 1`] = `6931`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 224091083899144559674927752909 gas 1`] = `2363`;
+exports[`TickMath #getTickAtSqrtRatio ratio 224091083899144559674927752909 gas 1`] = `2306`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 224091083899144559674927752909 result 1`] = `20795`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 633825300114114700748351602688 gas 1`] = `2376`;
+exports[`TickMath #getTickAtSqrtRatio ratio 633825300114114700748351602688 gas 1`] = `2319`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 633825300114114700748351602688 result 1`] = `41590`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000 gas 1`] = `2401`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000 gas 1`] = `2344`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000 result 1`] = `138162`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000000 gas 1`] = `2401`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000000 gas 1`] = `2344`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000000 result 1`] = `276324`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 1461446703485210103287273052203988822378723970341 gas 1`] = `2414`;
+exports[`TickMath #getTickAtSqrtRatio ratio 1461446703485210103287273052203988822378723970341 gas 1`] = `2357`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 1461446703485210103287273052203988822378723970341 result 1`] = `887271`;


### PR DESCRIPTION
Given that PoolManager is a singeton, it seems that we would optimize
for runtime cost rather than deployment cost since we only have to
deploy it once. IMO we should have our snapshots reflect gas changes
under this likely mainnet optimizer setting so we can accurately
determine real costs of any changes that we make.