### PR TITLE
IHookFeeManager and package.json licenses

### DIFF
--- a/contracts/interfaces/IHookFeeManager.sol
+++ b/contracts/interfaces/IHookFeeManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.19;
 
 import {IPoolManager} from "./IPoolManager.sol";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/core-next",
   "description": "🦄 Uniswap Protocol smart contracts",
-  "license": "UNLICENSED",
+  "license": "BUSL-1.1",
   "publishConfig": {
     "access": "restricted"
   },


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve? #224 

## Description of changes
- Putting GPL license on IHookFeeManager
- Putting BUSL1.1 license in package.json