### PR TITLE
⚡ Save sload in Owned.sol

### DIFF
--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -22,7 +22,7 @@ contract Owned {
     }
 
     function setOwner(address _owner) external onlyOwner {
-        emit OwnerChanged(owner, _owner);
+        emit OwnerChanged(msg.sender, _owner);
         owner = _owner;
     }
 }


### PR DESCRIPTION
Since `setOwner()` is `onlyOwner` restricted, and there is already a check that `msg.sender` is `owner`, we can just pass `msg.sender` into change event rather than loading owner again.