### PR TITLE
optimise settle function can save gas

### DIFF
--- a/contracts/PoolManager.sol
+++ b/contracts/PoolManager.sol
@@ -368,8 +368,9 @@ contract PoolManager is IPoolManager, Owned, NoDelegateCall, ERC1155, IERC1155Re
     /// @inheritdoc IPoolManager
     function settle(Currency currency) external payable override noDelegateCall onlyByLocker returns (uint256 paid) {
         uint256 reservesBefore = reservesOf[currency];
-        reservesOf[currency] = currency.balanceOfSelf();
-        paid = reservesOf[currency] - reservesBefore;
+        uint256 reservesNow = currency.balanceOfSelf();
+        reservesOf[currency] = reservesNow;
+        paid = reservesNow - reservesBefore;
         // subtraction must be safe
         _accountDelta(currency, -(paid.toInt128()));
     }


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve?

https://github.com/Uniswap/v4-core/issues/268

## Description of changes

Use 

https://github.com/Uniswap/v4-core/blob/d8c1ceed2a029cef8a9249f799c2a996bfa27107/contracts/PoolManager.sol#L369-L376

```solidity=369
    function settle(Currency currency) external payable override noDelegateCall onlyByLocker returns (uint256 paid) {
        uint256 reservesBefore = reservesOf[currency];
        reservesOf[currency] = currency.balanceOfSelf();
        paid = reservesOf[currency] - reservesBefore;
        // subtraction must be safe
        _accountDelta(currency, -(paid.toInt128()));
    }
```