### PR TITLE
fix: add proper hook for example in comment

### DIFF
--- a/contracts/libraries/Hooks.sol
+++ b/contracts/libraries/Hooks.sol
@@ -7,7 +7,7 @@ import {Fees} from "../libraries/Fees.sol";
 /// @notice V4 decides whether to invoke specific hooks by inspecting the leading bits of the address that
 /// the hooks contract is deployed to.
 /// For example, a hooks contract deployed to address: 0x9000000000000000000000000000000000000000
-/// has leading bits '1001' which would cause the 'before initialize' and 'after swap' hooks to be used.
+/// has leading bits '1001' which would cause the 'before initialize' and 'after modify position' hooks to be used.
 library Hooks {
     using Fees for uint24;
 


### PR DESCRIPTION
## Description of changes

Fix example in comment. Forth hook is called in this example, not after swap.