### PR TITLE
add burn test #197

### DIFF
--- a/contracts/test/PoolBurnTest.sol
+++ b/contracts/test/PoolBurnTest.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import {Currency, CurrencyLibrary} from "../libraries/CurrencyLibrary.sol";
+import {IERC20Minimal} from "../interfaces/external/IERC20Minimal.sol";
+
+import {ILockCallback} from "../interfaces/callback/ILockCallback.sol";
+import {IPoolManager} from "../interfaces/IPoolManager.sol";
+
+contract PoolBurnTest is ILockCallback {
+    using CurrencyLibrary for Currency;
+
+    IPoolManager public immutable manager;
+
+    constructor(IPoolManager _manager) {
+        manager = _manager;
+    }
+
+    // struct CallbackData
+    struct CallbackData {
+        address sender;
+        bool isMint;
+        IPoolManager.PoolKey key;
+        uint256 amount0;
+        uint256 amount1;
+    }
+
+    function mint(IPoolManager.PoolKey memory key, uint256 amount0, uint256 amount1) external {
+        manager.lock(abi.encode(CallbackData(msg.sender, true, key, amount0, amount1)));
+    }
+
+    function burn(IPoolManager.PoolKey memory key, uint256 amount0, uint256 amount1) external {
+        manager.lock(abi.encode(CallbackData(msg.sender, false, key, amount0, amount1)));
+    }
+
+    function lockAcquired(uint256, bytes calldata rawData) external returns (bytes memory) {
+        require(msg.sender == address(manager));
+
+        CallbackData memory data = abi.decode(rawData, (CallbackData));
+
+        if (data.isMint) {
+            if (data.amount0 > 0) {
+                uint256 currencyBalBefore = IERC20Minimal(Currency.unwrap(data.key.currency0)).balanceOf(data.sender);
+                uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency0.toId());
+                manager.mint(data.key.currency0, data.sender, data.amount0);
+                IERC20Minimal(Currency.unwrap(data.key.currency0)).transferFrom(
+                    data.sender, address(manager), uint128(data.amount0)
+                );
+                manager.settle(data.key.currency0);
+                uint256 currencyBalAfter = IERC20Minimal(Currency.unwrap(data.key.currency0)).balanceOf(data.sender);
+                uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency0.toId());
+                require(currencyBalBefore - currencyBalAfter == data.amount0);
+                require(managerBalAfter - managerBalBefore == data.amount0);
+            }
+            if (data.amount1 > 0) {
+                uint256 currencyBalBefore = IERC20Minimal(Currency.unwrap(data.key.currency1)).balanceOf(data.sender);
+                uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency1.toId());
+                manager.mint(data.key.currency1, data.sender, data.amount1);
+                IERC20Minimal(Currency.unwrap(data.key.currency1)).transferFrom(
+                    data.sender, address(manager), uint128(data.amount1)
+                );
+                manager.settle(data.key.currency1);
+                uint256 currencyBalAfter = IERC20Minimal(Currency.unwrap(data.key.currency1)).balanceOf(data.sender);
+                uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency1.toId());
+                require(currencyBalBefore - currencyBalAfter == data.amount1);
+                require(managerBalAfter - managerBalBefore == data.amount1);
+            }
+        } else {
+            if (data.amount0 > 0) {
+                uint256 currencyBalBefore = IERC20Minimal(Currency.unwrap(data.key.currency0)).balanceOf(data.sender);
+                uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency0.toId());
+                manager.take(data.key.currency0, data.sender, data.amount0);
+                manager.safeTransferFrom(data.sender, address(manager), data.key.currency0.toId(), data.amount0, "");
+                manager.settle(data.key.currency0);
+                uint256 currencyBalAfter = IERC20Minimal(Currency.unwrap(data.key.currency0)).balanceOf(data.sender);
+                uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency0.toId());
+                require(currencyBalAfter - currencyBalBefore == data.amount0);
+                require(managerBalBefore - managerBalAfter == data.amount0);
+            }
+            if (data.amount1 > 0) {
+                uint256 currencyBalBefore = IERC20Minimal(Currency.unwrap(data.key.currency1)).balanceOf(data.sender);
+                uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency1.toId());
+                manager.take(data.key.currency1, data.sender, data.amount1);
+                manager.safeTransferFrom(data.sender, address(manager), data.key.currency1.toId(), data.amount1, "");
+                manager.settle(data.key.currency1);
+                uint256 currencyBalAfter = IERC20Minimal(Currency.unwrap(data.key.currency1)).balanceOf(data.sender);
+                uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency1.toId());
+                require(currencyBalAfter - currencyBalBefore == data.amount1);
+                require(managerBalBefore - managerBalAfter == data.amount1);
+            }
+        }
+
+        return abi.encode(0);
+    }
+
+    function transferToManager(Currency currency, uint256 amount) external {
+        manager.safeTransferFrom(msg.sender, address(manager), currency.toId(), amount, "");
+    }
+}

--- a/contracts/test/PoolBurnTest.sol
+++ b/contracts/test/PoolBurnTest.sol
@@ -49,7 +49,6 @@ contract PoolBurnTest is ILockCallback {
         if (data.isMint) {
             if (data.amount0 > 0) {
                 uint256 currencyBalBefore = balanceOf(data.key.currency0, data.sender);
-                uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency0.toId());
                 manager.mint(data.key.currency0, data.sender, data.amount0);
 
                 if (data.key.currency0.isNative()) {
@@ -62,13 +61,10 @@ contract PoolBurnTest is ILockCallback {
                 }
 
                 uint256 currencyBalAfter = balanceOf(data.key.currency0, data.sender);
-                uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency0.toId());
                 require(data.key.currency0.isNative() || currencyBalBefore - currencyBalAfter == data.amount0);
-                require(managerBalAfter - managerBalBefore == data.amount0);
             }
             if (data.amount1 > 0) {
                 uint256 currencyBalBefore = balanceOf(data.key.currency1, data.sender);
-                uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency1.toId());
                 manager.mint(data.key.currency1, data.sender, data.amount1);
 
                 if (data.key.currency1.isNative()) {
@@ -81,32 +77,24 @@ contract PoolBurnTest is ILockCallback {
                 }
 
                 uint256 currencyBalAfter = balanceOf(data.key.currency1, data.sender);
-                uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency1.toId());
                 require(data.key.currency1.isNative() || currencyBalBefore - currencyBalAfter == data.amount1);
-                require(managerBalAfter - managerBalBefore == data.amount1);
             }
         } else {
             if (data.amount0 > 0) {
                 uint256 currencyBalBefore = balanceOf(data.key.currency0, data.sender);
-                uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency0.toId());
                 manager.take(data.key.currency0, data.sender, data.amount0);
                 manager.safeTransferFrom(data.sender, address(manager), data.key.currency0.toId(), data.amount0, "");
                 manager.settle(data.key.currency0);
                 uint256 currencyBalAfter = balanceOf(data.key.currency0, data.sender);
-                uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency0.toId());
                 require(currencyBalAfter - currencyBalBefore == data.amount0);
-                require(managerBalBefore - managerBalAfter == data.amount0);
             }
             if (data.amount1 > 0) {
                 uint256 currencyBalBefore = balanceOf(data.key.currency1, data.sender);
-                uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency1.toId());
                 manager.take(data.key.currency1, data.sender, data.amount1);
                 manager.safeTransferFrom(data.sender, address(manager), data.key.currency1.toId(), data.amount1, "");
                 manager.settle(data.key.currency1);
                 uint256 currencyBalAfter = balanceOf(data.key.currency1, data.sender);
-                uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency1.toId());
                 require(currencyBalAfter - currencyBalBefore == data.amount1);
-                require(managerBalBefore - managerBalAfter == data.amount1);
             }
         }
 

--- a/contracts/test/PoolBurnTest.sol
+++ b/contracts/test/PoolBurnTest.sol
@@ -25,12 +25,20 @@ contract PoolBurnTest is ILockCallback {
         uint256 amount1;
     }
 
-    function mint(IPoolManager.PoolKey memory key, uint256 amount0, uint256 amount1) external {
+    function mint(IPoolManager.PoolKey memory key, uint256 amount0, uint256 amount1) external payable {
         manager.lock(abi.encode(CallbackData(msg.sender, true, key, amount0, amount1)));
     }
 
     function burn(IPoolManager.PoolKey memory key, uint256 amount0, uint256 amount1) external {
         manager.lock(abi.encode(CallbackData(msg.sender, false, key, amount0, amount1)));
+    }
+
+    function balanceOf(Currency currency, address user) internal view returns (uint256) {
+        if (currency.isNative()) {
+            return user.balance;
+        } else {
+            return IERC20Minimal(Currency.unwrap(currency)).balanceOf(user);
+        }
     }
 
     function lockAcquired(uint256, bytes calldata rawData) external returns (bytes memory) {
@@ -40,50 +48,62 @@ contract PoolBurnTest is ILockCallback {
 
         if (data.isMint) {
             if (data.amount0 > 0) {
-                uint256 currencyBalBefore = IERC20Minimal(Currency.unwrap(data.key.currency0)).balanceOf(data.sender);
+                uint256 currencyBalBefore = balanceOf(data.key.currency0, data.sender);
                 uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency0.toId());
                 manager.mint(data.key.currency0, data.sender, data.amount0);
-                IERC20Minimal(Currency.unwrap(data.key.currency0)).transferFrom(
-                    data.sender, address(manager), uint128(data.amount0)
-                );
-                manager.settle(data.key.currency0);
-                uint256 currencyBalAfter = IERC20Minimal(Currency.unwrap(data.key.currency0)).balanceOf(data.sender);
+
+                if (data.key.currency0.isNative()) {
+                    manager.settle{value: uint256(data.amount0)}(data.key.currency0);
+                } else {
+                    IERC20Minimal(Currency.unwrap(data.key.currency0)).transferFrom(
+                        data.sender, address(manager), uint256(data.amount0)
+                    );
+                    manager.settle(data.key.currency0);
+                }
+
+                uint256 currencyBalAfter = balanceOf(data.key.currency0, data.sender);
                 uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency0.toId());
-                require(currencyBalBefore - currencyBalAfter == data.amount0);
+                require(data.key.currency0.isNative() || currencyBalBefore - currencyBalAfter == data.amount0);
                 require(managerBalAfter - managerBalBefore == data.amount0);
             }
             if (data.amount1 > 0) {
-                uint256 currencyBalBefore = IERC20Minimal(Currency.unwrap(data.key.currency1)).balanceOf(data.sender);
+                uint256 currencyBalBefore = balanceOf(data.key.currency1, data.sender);
                 uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency1.toId());
                 manager.mint(data.key.currency1, data.sender, data.amount1);
-                IERC20Minimal(Currency.unwrap(data.key.currency1)).transferFrom(
-                    data.sender, address(manager), uint128(data.amount1)
-                );
-                manager.settle(data.key.currency1);
-                uint256 currencyBalAfter = IERC20Minimal(Currency.unwrap(data.key.currency1)).balanceOf(data.sender);
+
+                if (data.key.currency1.isNative()) {
+                    manager.settle{value: uint256(data.amount1)}(data.key.currency1);
+                } else {
+                    IERC20Minimal(Currency.unwrap(data.key.currency1)).transferFrom(
+                        data.sender, address(manager), uint256(data.amount1)
+                    );
+                    manager.settle(data.key.currency1);
+                }
+
+                uint256 currencyBalAfter = balanceOf(data.key.currency1, data.sender);
                 uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency1.toId());
-                require(currencyBalBefore - currencyBalAfter == data.amount1);
+                require(data.key.currency1.isNative() || currencyBalBefore - currencyBalAfter == data.amount1);
                 require(managerBalAfter - managerBalBefore == data.amount1);
             }
         } else {
             if (data.amount0 > 0) {
-                uint256 currencyBalBefore = IERC20Minimal(Currency.unwrap(data.key.currency0)).balanceOf(data.sender);
+                uint256 currencyBalBefore = balanceOf(data.key.currency0, data.sender);
                 uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency0.toId());
                 manager.take(data.key.currency0, data.sender, data.amount0);
                 manager.safeTransferFrom(data.sender, address(manager), data.key.currency0.toId(), data.amount0, "");
                 manager.settle(data.key.currency0);
-                uint256 currencyBalAfter = IERC20Minimal(Currency.unwrap(data.key.currency0)).balanceOf(data.sender);
+                uint256 currencyBalAfter = balanceOf(data.key.currency0, data.sender);
                 uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency0.toId());
                 require(currencyBalAfter - currencyBalBefore == data.amount0);
                 require(managerBalBefore - managerBalAfter == data.amount0);
             }
             if (data.amount1 > 0) {
-                uint256 currencyBalBefore = IERC20Minimal(Currency.unwrap(data.key.currency1)).balanceOf(data.sender);
+                uint256 currencyBalBefore = balanceOf(data.key.currency1, data.sender);
                 uint256 managerBalBefore = manager.balanceOf(data.sender, data.key.currency1.toId());
                 manager.take(data.key.currency1, data.sender, data.amount1);
                 manager.safeTransferFrom(data.sender, address(manager), data.key.currency1.toId(), data.amount1, "");
                 manager.settle(data.key.currency1);
-                uint256 currencyBalAfter = IERC20Minimal(Currency.unwrap(data.key.currency1)).balanceOf(data.sender);
+                uint256 currencyBalAfter = balanceOf(data.key.currency1, data.sender);
                 uint256 managerBalAfter = manager.balanceOf(data.sender, data.key.currency1.toId());
                 require(currencyBalAfter - currencyBalBefore == data.amount1);
                 require(managerBalBefore - managerBalAfter == data.amount1);

--- a/test/foundry-tests/PoolManager.t.sol
+++ b/test/foundry-tests/PoolManager.t.sol
@@ -549,7 +549,7 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
         uint256 amount1 = 1 ether;
 
         IPoolManager.PoolKey memory key = IPoolManager.PoolKey({
-            currency0: currency0,
+            currency0: Currency.wrap(address(0)),
             currency1: currency1,
             fee: 3000,
             hooks: IHooks(address(0)),
@@ -558,7 +558,7 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
 
         manager.initialize(key, SQRT_RATIO_1_1);
         manager.setApprovalForAll(address(burnRouter), true);
-        burnRouter.mint(key, amount0, amount1);
+        burnRouter.mint{value: amount0}(key, amount0, amount1);
 
         burnRouter.burn(key, amount0, amount1);
     }
@@ -568,7 +568,7 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
         uint256 amount1 = 1 ether;
 
         IPoolManager.PoolKey memory key = IPoolManager.PoolKey({
-            currency0: currency0,
+            currency0: Currency.wrap(address(0)),
             currency1: currency1,
             fee: 3000,
             hooks: IHooks(address(0)),
@@ -577,7 +577,7 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
 
         manager.initialize(key, SQRT_RATIO_1_1);
         manager.setApprovalForAll(address(burnRouter), true);
-        burnRouter.mint(key, amount0, amount1);
+        burnRouter.mint{value: amount0}(key, amount0, amount1);
 
         // -vvv "ERC1155: transfer to non ERC1155Receiver implementer" => "Arithmetic over/underflow"
         vm.expectRevert(bytes("ERC1155: transfer to non ERC1155Receiver implementer"));

--- a/test/foundry-tests/PoolManager.t.sol
+++ b/test/foundry-tests/PoolManager.t.sol
@@ -561,6 +561,12 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
         burnRouter.mint{value: amount0}(key, amount0, amount1);
 
         burnRouter.burn(key, amount0, amount1);
+
+        uint256 erc1155Currency0Balance =
+            manager.balanceOf(address(this), CurrencyLibrary.toId(Currency.wrap(address(0))));
+        uint256 erc1155Currency1Balance = manager.balanceOf(address(this), CurrencyLibrary.toId(currency1));
+        assertEq(erc1155Currency0Balance, 0);
+        assertEq(erc1155Currency1Balance, 0);
     }
 
     function testBurnFailsWithoutLock() public {
@@ -585,6 +591,12 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
 
         vm.expectRevert(bytes("ERC1155: transfer to non ERC1155Receiver implementer"));
         burnRouter.transferToManager(key.currency1, amount1);
+
+        uint256 erc1155Currency0Balance =
+            manager.balanceOf(address(this), CurrencyLibrary.toId(Currency.wrap(address(0))));
+        uint256 erc1155Currency1Balance = manager.balanceOf(address(this), CurrencyLibrary.toId(currency1));
+        assertEq(erc1155Currency0Balance, amount0);
+        assertEq(erc1155Currency1Balance, amount1);
     }
 
     function testGasMint() public {


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve?
#197 

## Description of changes
Add test to confirm that burn outside of lock would revert. This is because lockedBy.length is 0 and therefore an underflow error in [_accountDelta](https://github.com/Uniswap/v4-core/blob/d8c1ceed2a029cef8a9249f799c2a996bfa27107/contracts/PoolManager.sol#L183)

> Secondly what if an unsafe transfer is done

unsafe transfer is [impossible](https://forum.openzeppelin.com/t/unsafe-transfer-in-erc1155/18758) cause OZ implementation strictly complies with the [ERC1155 spec](https://eips.ethereum.org/EIPS/eip-1155).
