### PR TITLE
docs: fix natspec comment on PriceLimitAlreadyExceeded

### DIFF
--- a/contracts/libraries/Pool.sol
+++ b/contracts/libraries/Pool.sol
@@ -48,7 +48,7 @@ library Pool {
 
     /// @notice Thrown when sqrtPriceLimitX96 on a swap has already exceeded its limit
     /// @param sqrtPriceCurrentX96 The invalid, already surpassed sqrtPriceLimitX96
-    /// @param sqrtPriceLimitX96 The invalid, already surpassed sqrtPriceLimitX96
+    /// @param sqrtPriceLimitX96 The surpassed price limit
     error PriceLimitAlreadyExceeded(uint160 sqrtPriceCurrentX96, uint160 sqrtPriceLimitX96);
 
     /// @notice Thrown when sqrtPriceLimitX96 lies outside of valid tick/price range


### PR DESCRIPTION
## Related Issue
Wrong comment on `PriceLimitAlreadyExceeded` error

## Description of changes
Update natspec