### PR TITLE
Gas optimisation `swap` Pool.sol

### DIFF
--- a/contracts/libraries/Pool.sol
+++ b/contracts/libraries/Pool.sol
@@ -377,7 +377,7 @@ library Pool {
         if (params.amountSpecified == 0) revert SwapAmountCannotBeZero();
 
         Slot0 memory slot0Start = self.slot0;
-        if (self.slot0.sqrtPriceX96 == 0) revert PoolNotInitialized();
+        if (slot0Start.sqrtPriceX96 == 0) revert PoolNotInitialized();
         if (params.zeroForOne) {
             if (params.sqrtPriceLimitX96 >= slot0Start.sqrtPriceX96) {
                 revert PriceLimitAlreadyExceeded(slot0Start.sqrtPriceX96, params.sqrtPriceLimitX96);


### PR DESCRIPTION
## Related Issue
Gas Optimisation

## Description of changes
Minor gas optimisation read from memory struct will cost less comparison to storage struct.

changed from `self.slot0` -> `slot0Start`