### PR TITLE
docs: fix typo on mulDiv comments

### DIFF
--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -94,7 +94,7 @@ library FullMath {
 
             // Because the division is now exact we can divide by multiplying
             // with the modular inverse of denominator. This will give us the
-            // correct result modulo 2**256. Since the precoditions guarantee
+            // correct result modulo 2**256. Since the preconditions guarantee
             // that the outcome is less than 2**256, this is the final result.
             // We don't need to compute the high bits of the result and prod1
             // is no longer required.


### PR DESCRIPTION
## Related Issue
Appears to be a typo on 'preconditions' in mulDiv comments

## Description of changes
Update comments, correcting typo 