### PR TITLE
Use specific release tag for OpenZeppelin Contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,4 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+	branch = v4.9.3


### PR DESCRIPTION
Has mentionned [here](https://github.com/OpenZeppelin/openzeppelin-contracts#foundry-git), the default (master) branch of [Openzeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) is not safe for production. We recommand using a release branch or tag.