### PR TITLE
Fix shadowed state var

### DIFF
--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -76,13 +76,13 @@ contract PoolManager is IPoolManager, Fees, NoDelegateCall, Claims {
         return pools[id].positions.get(_owner, tickLower, tickUpper).liquidity;
     }
 
-    function getPosition(PoolId id, address owner, int24 tickLower, int24 tickUpper)
+    function getPosition(PoolId id, address _owner, int24 tickLower, int24 tickUpper)
         external
         view
         override
         returns (Position.Info memory position)
     {
-        return pools[id].positions.get(owner, tickLower, tickUpper);
+        return pools[id].positions.get(_owner, tickLower, tickUpper);
     }
 
     /// @inheritdoc IPoolManager


### PR DESCRIPTION
## Description of changes

Fixes shadowed state variable `owner` in `getPosition` by adding an underscore to the param as was done in `getLiquidity`