### PR TITLE
feat: Increment MIN_PROTOCOL_FEE_DENOMINATOR from 4 to 10

### DIFF
--- a/contracts/Fees.sol
+++ b/contracts/Fees.sol
@@ -14,7 +14,7 @@ abstract contract Fees is IFees, Owned {
     using FeeLibrary for uint24;
     using CurrencyLibrary for Currency;
 
-    uint8 public constant MIN_PROTOCOL_FEE_DENOMINATOR = 4;
+    uint8 public constant MIN_PROTOCOL_FEE_DENOMINATOR = 10;
 
     mapping(Currency currency => uint256) public protocolFeesAccrued;
 


### PR DESCRIPTION
On 25 of August, an infamous tax proposal ruled that: "The Treasury Department and the IRS expect that this clarified proposed definition will ultimately require operators of some platforms generally referred to as decentralized exchanges to collect customer information and report sales information about their customers, if those operators otherwise qualify as brokers."

The tax proposal mandates any protocol who can change its fees, to increase them to a maximum to force users to stop using/move to a KYC'd version.

Hereby, to minimize the upfront of maximized protocol fees, I propose for them to only by 10% (at maximum) of the pool fees, instead of the current 25%.
Other solutions would be to launch without the possibility of changing protocol fees, or incrementing even more the
MIN_PROTOCOL_FEE_DENOMINATOR to minimize damage if such a proposal passes.

Source: https://public-inspection.federalregister.gov/2023-17565.pdf