### PR TITLE
chore: remove double import in PoolManager.sol

### DIFF
--- a/contracts/PoolManager.sol
+++ b/contracts/PoolManager.sol
@@ -21,7 +21,6 @@ import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import {PoolId, PoolIdLibrary} from "./types/PoolId.sol";
 import {BalanceDelta} from "./types/BalanceDelta.sol";
-import {PoolKey} from "./types/PoolKey.sol";
 
 /// @notice Holds the state for all pools
 contract PoolManager is IPoolManager, Fees, NoDelegateCall, ERC1155, IERC1155Receiver {


### PR DESCRIPTION
## Description of changes

Identify an issue that I believe is a typo. There is two import in PoolManager of PoolKey.