### PR TITLE
Migrate functionality from setProtocolFeeController to testPoolManagerFeeControllerSet

### DIFF
--- a/test/PoolManager.spec.ts
+++ b/test/PoolManager.spec.ts
@@ -107,17 +107,6 @@ describe('PoolManager', () => {
     expect(((await waffle.provider.getCode(manager.address)).length - 2) / 2).to.matchSnapshot()
   })
 
-  describe('#setProtocolFeeController', () => {
-    it('allows the owner to set a fee controller', async () => {
-      expect(await manager.protocolFeeController()).to.be.eq(ADDRESS_ZERO)
-      await expect(manager.setProtocolFeeController(feeControllerTest.address)).to.emit(
-        manager,
-        'ProtocolFeeControllerUpdated'
-      )
-      expect(await manager.protocolFeeController()).to.be.eq(feeControllerTest.address)
-    })
-  })
-
   describe('#take', () => {
     it('fails if no liquidity', async () => {
       await tokens.currency0.connect(wallet).transfer(ADDRESS_ZERO, constants.MaxUint256.div(2))

--- a/test/foundry-tests/PoolManager.t.sol
+++ b/test/foundry-tests/PoolManager.t.sol
@@ -38,6 +38,7 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
     using CurrencyLibrary for Currency;
 
     event LockAcquired();
+    event ProtocolFeeControllerUpdated(address protocolFeeController);
     event Initialize(
         PoolId indexed poolId,
         Currency indexed currency0,
@@ -340,6 +341,8 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
 
     function testPoolManagerFeeControllerSet() public {
         assertEq(address(manager.protocolFeeController()), address(0));
+        vm.expectEmit(false, false, false, true);
+        emit ProtocolFeeControllerUpdated(address(protocolFeeController));
         manager.setProtocolFeeController(protocolFeeController);
         assertEq(address(manager.protocolFeeController()), address(protocolFeeController));
     }

--- a/test/foundry-tests/PoolManager.t.sol
+++ b/test/foundry-tests/PoolManager.t.sol
@@ -341,7 +341,7 @@ contract PoolManagerTest is Test, Deployers, TokenFixture, GasSnapshot, IERC1155
 
     function testPoolManagerFeeControllerSet() public {
         assertEq(address(manager.protocolFeeController()), address(0));
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(false, false, false, true, address(manager));
         emit ProtocolFeeControllerUpdated(address(protocolFeeController));
         manager.setProtocolFeeController(protocolFeeController);
         assertEq(address(manager.protocolFeeController()), address(protocolFeeController));


### PR DESCRIPTION
## Related Issue

This PR addresses part of Issue #315, porting `PoolManager` test cases from hardhat to foundry. 

## Description of changes

Finish porting the final piece of functionality from `setProtocolFeeController` in `PoolManager.spec.ts` to the associated test case `testPoolManagerFeeControllerSet` in `PoolManager.t.sol`. 

These tests were almost the same, except that `testPoolManagerFeeControllerSet` didn't check for the `ProtocolFeeControllerUpdated` event, now it checks for that event so it seems safe to remove the redundant test `setProtocolFeeController` from `PoolManager.spec.ts`.