### PR TITLE
Use ONE_HUNDRED_PERCENT for swap fee cap

### DIFF
--- a/contracts/PoolManager.sol
+++ b/contracts/PoolManager.sol
@@ -33,6 +33,7 @@ contract PoolManager is IPoolManager, Fees, NoDelegateCall, ERC1155, IERC1155Rec
     using LockDataLibrary for IPoolManager.LockData;
     using FeeLibrary for uint24;
 
+    int24 public constant ONE_HUNDRED_PERCENT = 1000000;
     /// @inheritdoc IPoolManager
     int24 public constant override MAX_TICK_SPACING = type(int16).max;
 
@@ -255,7 +256,7 @@ contract PoolManager is IPoolManager, Fees, NoDelegateCall, ERC1155, IERC1155Rec
         uint24 totalSwapFee;
         if (key.fee.isDynamicFee()) {
             totalSwapFee = IDynamicFeeManager(address(key.hooks)).getFee(msg.sender, key, params, hookData);
-            if (totalSwapFee >= 1000000) revert FeeTooLarge();
+            if (totalSwapFee >= ONE_HUNDRED_PERCENT) revert FeeTooLarge();
         } else {
             // clear the top 4 bits since they may be flagged for hook fees
             totalSwapFee = key.fee.getStaticFee();

--- a/test/foundry-tests/Pool.t.sol
+++ b/test/foundry-tests/Pool.t.sol
@@ -13,6 +13,7 @@ contract PoolTest is Test {
     using Pool for Pool.State;
 
     Pool.State state;
+    int24 public constant ONE_HUNDRED_PERCENT = 1000000;
 
     function testPoolInitialize(uint160 sqrtPriceX96, uint16 protocolFee, uint16 hookFee) public {
         vm.assume(protocolFee < 2 ** 12 && hookFee < 2 ** 12);
@@ -75,7 +76,7 @@ contract PoolTest is Test {
         // Assumptions tested in PoolManager.t.sol
         vm.assume(params.tickSpacing > 0);
         vm.assume(params.tickSpacing < 32768);
-        vm.assume(params.fee < 1000000);
+        vm.assume(params.fee < ONE_HUNDRED_PERCENT);
 
         testPoolInitialize(sqrtPriceX96, 0, 0);
         Pool.Slot0 memory slot0 = state.slot0;


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve?

The swap fee percentage can not exceed 100% and it's written in the smart contract at `PoolManager.sol`. 
But the `1000000` in the smart contract is not easy to for people understand it's 100% and thus takes time to trace code and even guess.

## Description of changes

Change the `1000000` to a variable with a descriptive name `ONE_HUNDRED_PERCENT`.