### PR TITLE
Chore: update licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ contract MyContract is ILockCallback {
 
 The primary license for Uniswap V4 Core is the Business Source License 1.1 (`BUSL-1.1`), see [LICENSE](https://github.com/Uniswap/v4-core/blob/main/LICENSE). Minus the following exceptions:
 
-- [Interfaces](./contracts/interfaces) have a General Public License
-- Some [libraries](./contracts/libraries) and [types](./contracts/types/) have a General Public License
-- [FullMath.sol](./contracts/libraries/FullMath.sol) has an MIT License
+- Some [libraries](./contracts/libraries) have a GPL license
+- Both [FullMath.sol](./contracts/libraries/FullMath.sol) and [Hooks.sol](./contracts/libraries/Hooks.sol) have an MIT License
+- [Interfaces](./contracts/interfaces) and [types](./contracts/types/) have an MIT license
 
 Each of these files states their license type.

--- a/contracts/interfaces/IDynamicFeeManager.sol
+++ b/contracts/interfaces/IDynamicFeeManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {PoolKey} from "../types/PoolKey.sol";

--- a/contracts/interfaces/IFees.sol
+++ b/contracts/interfaces/IFees.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 import {Currency} from "../types/Currency.sol";

--- a/contracts/interfaces/IHookFeeManager.sol
+++ b/contracts/interfaces/IHookFeeManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {PoolKey} from "../types/PoolKey.sol";

--- a/contracts/interfaces/IHooks.sol
+++ b/contracts/interfaces/IHooks.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {PoolKey} from "../types/PoolKey.sol";

--- a/contracts/interfaces/IPoolManager.sol
+++ b/contracts/interfaces/IPoolManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {Currency} from "../types/Currency.sol";

--- a/contracts/interfaces/IProtocolFeeController.sol
+++ b/contracts/interfaces/IProtocolFeeController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {PoolKey} from "../types/PoolKey.sol";

--- a/contracts/interfaces/callback/ILockCallback.sol
+++ b/contracts/interfaces/callback/ILockCallback.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 interface ILockCallback {

--- a/contracts/libraries/Hooks.sol
+++ b/contracts/libraries/Hooks.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {IHooks} from "../interfaces/IHooks.sol";

--- a/contracts/types/BalanceDelta.sol
+++ b/contracts/types/BalanceDelta.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 type BalanceDelta is int256;

--- a/contracts/types/Currency.sol
+++ b/contracts/types/Currency.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {IERC20Minimal} from "../interfaces/external/IERC20Minimal.sol";

--- a/contracts/types/PoolId.sol
+++ b/contracts/types/PoolId.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {PoolKey} from "./PoolKey.sol";

--- a/contracts/types/PoolKey.sol
+++ b/contracts/types/PoolKey.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 import {Currency} from "./Currency.sol";


### PR DESCRIPTION
## Related Issue
Various `types`, `interfaces`, and `libraries` found in the core v4 repository will likely be required imports to any hook contracts or protocols that are built on top of v4. In talking to developers who are likely to build these types of contracts and protocols, the Uniswap Foundation has surfaced a common concern around the restrictions enforced by the GPL license on the files in the `types` and `interfaces` directories, as well as one specific library, `Hooks.sol` 

## Description of changes
This PR changes the SPDX License Identifier in all files mentioned above to `MIT`. It also edits the **License** section of the  README to note the new exceptions to the BUSL that governs most of the repository.