### PR TITLE
Fixing compiler warnings

### DIFF
--- a/contracts/test/BaseTestHooks.sol
+++ b/contracts/test/BaseTestHooks.sol
@@ -9,78 +9,79 @@ import {IPoolManager} from "../interfaces/IPoolManager.sol";
 contract BaseTestHooks is IHooks {
     error HookNotImplemented();
 
-    function beforeInitialize(address sender, PoolKey calldata key, uint160 sqrtPriceX96, bytes calldata hookData)
-        external
-        virtual
-        returns (bytes4)
-    {
+    function beforeInitialize(
+        address, /* sender **/
+        PoolKey calldata, /* key **/
+        uint160, /* sqrtPriceX96 **/
+        bytes calldata /* hookData **/
+    ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
     function afterInitialize(
-        address sender,
-        PoolKey calldata key,
-        uint160 sqrtPriceX96,
-        int24 tick,
-        bytes calldata hookData
+        address, /* sender **/
+        PoolKey calldata, /* key **/
+        uint160, /* sqrtPriceX96 **/
+        int24, /* tick **/
+        bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
     function beforeModifyPosition(
-        address sender,
-        PoolKey calldata key,
-        IPoolManager.ModifyPositionParams calldata params,
-        bytes calldata hookData
+        address, /* sender **/
+        PoolKey calldata, /* key **/
+        IPoolManager.ModifyPositionParams calldata, /* params **/
+        bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
     function afterModifyPosition(
-        address sender,
-        PoolKey calldata key,
-        IPoolManager.ModifyPositionParams calldata params,
-        BalanceDelta delta,
-        bytes calldata hookData
+        address, /* sender **/
+        PoolKey calldata, /* key **/
+        IPoolManager.ModifyPositionParams calldata, /* params **/
+        BalanceDelta, /* delta **/
+        bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
     function beforeSwap(
-        address sender,
-        PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
-        bytes calldata hookData
+        address, /* sender **/
+        PoolKey calldata, /* key **/
+        IPoolManager.SwapParams calldata, /* params **/
+        bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
     function afterSwap(
-        address sender,
-        PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
-        BalanceDelta delta,
-        bytes calldata hookData
+        address, /* sender **/
+        PoolKey calldata, /* key **/
+        IPoolManager.SwapParams calldata, /* params **/
+        BalanceDelta, /* delta **/
+        bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
     function beforeDonate(
-        address sender,
-        PoolKey calldata key,
-        uint256 amount0,
-        uint256 amount1,
-        bytes calldata hookData
+        address, /* sender **/
+        PoolKey calldata, /* key **/
+        uint256, /* amount0 **/
+        uint256, /* amount1 **/
+        bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }
 
     function afterDonate(
-        address sender,
-        PoolKey calldata key,
-        uint256 amount0,
-        uint256 amount1,
-        bytes calldata hookData
+        address, /* sender **/
+        PoolKey calldata, /* key **/
+        uint256, /* amount0 **/
+        uint256, /* amount1 **/
+        bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
     }

--- a/test/foundry-tests/DynamicFees.t.sol
+++ b/test/foundry-tests/DynamicFees.t.sol
@@ -131,8 +131,7 @@ contract TestDynamicFees is Test, Deployers, GasSnapshot {
     }
 
     function testUpdateRevertsOnStaticFeePool() public {
-        (PoolKey memory staticPoolKey, PoolId id) =
-            Deployers.createPool(manager, IHooks(address(0)), 3000, SQRT_RATIO_1_1);
+        (PoolKey memory staticPoolKey,) = Deployers.createPool(manager, IHooks(address(0)), 3000, SQRT_RATIO_1_1);
         vm.expectRevert(IFees.FeeNotDynamic.selector);
         manager.updateDynamicSwapFee(staticPoolKey);
     }


### PR DESCRIPTION
## Description of changes

Fixes all the compiler warnings that you get when running `forge build`. It was making it hard to see if your new code was introducing issues.