### PR TITLE
chore: add fee collection signatures to the IFees interface

### DIFF
--- a/src/interfaces/IFees.sol
+++ b/src/interfaces/IFees.sol
@@ -21,4 +21,14 @@ interface IFees {
 
     /// @notice Given a hook and a currency address, returns the fees accrued
     function hookFeesAccrued(address, Currency) external view returns (uint256);
+
+    /// @notice Collect the protocol accrued fees, sent to a recipient
+    function collectProtocolFees(address recipient, Currency currency, uint256 amount)
+        external
+        returns (uint256 amountCollected);
+
+    /// @notice Collect a hook's accrued fees, sent to a recipient
+    function collectHookFees(address recipient, Currency currency, uint256 amount)
+        external
+        returns (uint256 amountCollected);
 }


### PR DESCRIPTION
## Related Issue
`IFees.sol` interface did not match the available signatures defined in `Fees.sol` (inherited by PoolManager)

## Description of changes

Added the `collectHookFees` and `collectProtocolFees` to the interface

---

Note: I'm happy to update the `Fees.t.sol` to use `IPoolManager` instead, so that we can catch missing signatures in the future

It would require some changes with how the tests are unpacking slot0:
```solidity
(Pool.Slot0 memory slot0,,,) = manager.pools(key0.toId());

changed to:

// now that manager is IPoolManager:
(uint160 sqrtPriceX96, int24 tick, uint24 protocolFees, uint24 hookFees) = manager.getSlot0(key0.toId());
Pool.Slot0 memory slot0 = Pool.Slot0(sqrtPriceX96, tick, protocolFees, hookFees);

```
