### PR TITLE
move Swap event before afterSwap hook

### DIFF
--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -247,7 +247,6 @@ contract PoolManager is IPoolManager, Fees, NoDelegateCall, ERC6909Claims {
         );
 
         key.hooks.afterSwap(key, params, delta, hookData);
-
     }
 
     /// @inheritdoc IPoolManager

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -201,9 +201,9 @@ contract PoolManager is IPoolManager, Fees, NoDelegateCall, ERC6909Claims {
 
         _accountPoolBalanceDelta(key, delta);
 
-        key.hooks.afterModifyLiquidity(key, params, delta, hookData);
-
         emit ModifyLiquidity(id, msg.sender, params.tickLower, params.tickUpper, params.liquidityDelta);
+
+        key.hooks.afterModifyLiquidity(key, params, delta, hookData);
     }
 
     /// @inheritdoc IPoolManager

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -242,11 +242,12 @@ contract PoolManager is IPoolManager, Fees, NoDelegateCall, ERC6909Claims {
             }
         }
 
-        key.hooks.afterSwap(key, params, delta, hookData);
-
         emit Swap(
             id, msg.sender, delta.amount0(), delta.amount1(), state.sqrtPriceX96, state.liquidity, state.tick, swapFee
         );
+
+        key.hooks.afterSwap(key, params, delta, hookData);
+
     }
 
     /// @inheritdoc IPoolManager


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve?

It is possible for afterSwap to do a reentrant call into swap on the same pool (and will be even easier after some potential changes to the locking pattern). If it does, then Swap events could fire out of order (because the second swap, which happens during the afterSwap hook, would finish and fire its event before the event from the first swap), which be confusing for data analysis.

## Description of changes

Moves the Swap event before the afterSwap hook, to prevent misordered Swap events.