### PR TITLE
Add Tests for maxUsableTick and minUsableTick Functions #468

### DIFF
--- a/src/test/TickMathTest.sol
+++ b/src/test/TickMathTest.sol
@@ -39,4 +39,12 @@ contract TickMathTest {
     function MAX_TICK() external pure returns (int24) {
         return TickMath.MAX_TICK;
     }
+
+    function maxUsableTick(int24 tickSpacing) external pure returns (int24) {
+        return TickMath.maxUsableTick(tickSpacing);
+    }
+
+    function minUsableTick(int24 tickSpacing) external pure returns (int24) {
+        return TickMath.minUsableTick(tickSpacing);
+    }
 }

--- a/test/TickMath.t.sol
+++ b/test/TickMath.t.sol
@@ -7,9 +7,6 @@ import {TickMathTest} from "../src/test/TickMathTest.sol";
 import {TickMath} from "../src/libraries/TickMath.sol";
 import {JavascriptFfi} from "./utils/JavascriptFfi.sol";
 
-// rm before git add .
-import "forge-std/console.sol";
-
 contract TickMathTestTest is Test, JavascriptFfi {
     int24 constant MIN_TICK = -887272;
     int24 constant MAX_TICK = -MIN_TICK;
@@ -67,11 +64,7 @@ contract TickMathTestTest is Test, JavascriptFfi {
         for (uint256 i = 0; i < feeTiers.length; i++) {
             FeeTier memory tier = feeTiers[i];
             int24 expectedMaxTick = (MAX_TICK / tier.tickSpacing) * tier.tickSpacing;
-            assertEq(
-                tickMath.maxUsableTick(tier.tickSpacing),
-                expectedMaxTick,
-                "Max usable tick does not match for fee tier."
-            );
+            assertEq(tickMath.maxUsableTick(tier.tickSpacing), expectedMaxTick);
         }
     }
 
@@ -90,11 +83,7 @@ contract TickMathTestTest is Test, JavascriptFfi {
         for (uint256 i = 0; i < feeTiers.length; i++) {
             FeeTier memory tier = feeTiers[i];
             int24 expectedMinTick = (MIN_TICK / tier.tickSpacing) * tier.tickSpacing;
-            assertEq(
-                tickMath.minUsableTick(tier.tickSpacing),
-                expectedMinTick,
-                "Min usable tick does not match for fee tier."
-            );
+            assertEq(tickMath.minUsableTick(tier.tickSpacing), expectedMinTick);
         }
     }
 
@@ -102,14 +91,14 @@ contract TickMathTestTest is Test, JavascriptFfi {
         vm.assume(tickSpacing > 0 && tickSpacing <= MAX_TICK && tickSpacing >= MIN_TICK);
 
         int24 expectedMaxTick = (MAX_TICK / tickSpacing) * tickSpacing;
-        assertEq(tickMath.maxUsableTick(tickSpacing), expectedMaxTick, "Max usable tick does not match for fee tier.");
+        assertEq(tickMath.maxUsableTick(tickSpacing), expectedMaxTick);
     }
 
     function testFuzz_minUsableTick_SpecificFeeTiers(int24 tickSpacing) public {
         vm.assume(tickSpacing > 0 && tickSpacing <= MAX_TICK && tickSpacing >= MIN_TICK);
 
         int24 expectedMinTick = (MIN_TICK / tickSpacing) * tickSpacing;
-        assertEq(tickMath.minUsableTick(tickSpacing), expectedMinTick, "Max usable tick does not match for fee tier.");
+        assertEq(tickMath.minUsableTick(tickSpacing), expectedMinTick);
     }
 
     function test_maxUsableTick_revertsForZero() public {


### PR DESCRIPTION
Following up on the stale PR: https://github.com/Uniswap/v4-core/pull/468

This commit introduces tests for the newly added utility functions `maxUsableTick` and `minUsableTick` in the TickMath library.

Added tests to check the min and max usable ticks in the `TickMath` library. 

Added 2 tests to check tick spacings for popular fee tiers.

Added 2 fuzzing tests.

Added 2 tests to check revert of min/max tick on 0. 
