### PR TITLE
[Bug] Revert back to relative path imports for Protocol Fee Logic

### DIFF
--- a/src/ProtocolFees.sol
+++ b/src/ProtocolFees.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.19;
 
-import {Currency, CurrencyLibrary} from "src/types/Currency.sol";
-import {IProtocolFeeController} from "src/interfaces/IProtocolFeeController.sol";
-import {IProtocolFees} from "src/interfaces/IProtocolFees.sol";
-import {PoolKey} from "src/types/PoolKey.sol";
-import {ProtocolFeeLibrary} from "src/libraries/ProtocolFeeLibrary.sol";
+import {Currency, CurrencyLibrary} from "./types/Currency.sol";
+import {IProtocolFeeController} from "./interfaces/IProtocolFeeController.sol";
+import {IProtocolFees} from "./interfaces/IProtocolFees.sol";
+import {PoolKey} from "./types/PoolKey.sol";
+import {ProtocolFeeLibrary} from "./libraries/ProtocolFeeLibrary.sol";
 import {Owned} from "solmate/auth/Owned.sol";
-import {PoolId, PoolIdLibrary} from "src/types/PoolId.sol";
-import {Pool} from "src/libraries/Pool.sol";
+import {PoolId, PoolIdLibrary} from "./types/PoolId.sol";
+import {Pool} from "./libraries/Pool.sol";
 
 abstract contract ProtocolFees is IProtocolFees, Owned {
     using CurrencyLibrary for Currency;

--- a/src/interfaces/IProtocolFees.sol
+++ b/src/interfaces/IProtocolFees.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import {Currency} from "src/types/Currency.sol";
-import {IProtocolFeeController} from "src/interfaces/IProtocolFeeController.sol";
-import {PoolId} from "src/types/PoolId.sol";
-import {PoolKey} from "src/types/PoolKey.sol";
+import {Currency} from "../types/Currency.sol";
+import {IProtocolFeeController} from "../interfaces/IProtocolFeeController.sol";
+import {PoolId} from "../types/PoolId.sol";
+import {PoolKey} from "../types/PoolKey.sol";
 
 interface IProtocolFees {
     /// @notice Thrown when not enough gas is provided to look up the protocol fee


### PR DESCRIPTION
## Related Issue
The import paths for protocol fee logic was changed from relative to fixed in https://github.com/Uniswap/v4-core/pull/546

This change broke default foundry compatibility with v4-periphery. There is a way to keep the current paths as-is, but requires adding:

`lib/v4-core:src/=lib/v4-core/src/` to v4-periphery's remappings.txt

its bit ugly, and a fair amount of devs will struggle with this, so best to adhere to patterns that foundry supports by default

## Description of changes

Change protocol fee imports from fixed paths to relative paths

