### PR TITLE
tests: Make and use a common SWAP_PARAMS in Deployers.sol

### DIFF
--- a/test/DynamicFees.t.sol
+++ b/test/DynamicFees.t.sol
@@ -113,13 +113,11 @@ contract TestDynamicFees is Test, Deployers, GasSnapshot {
 
         dynamicFeesHooks.setFee(1000001);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         vm.expectRevert(LPFeeLibrary.FeeTooLarge.selector);
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
     }
 
     function test_updateDynamicLPFee_beforeSwap_succeeds_gas() public {
@@ -127,15 +125,13 @@ contract TestDynamicFees is Test, Deployers, GasSnapshot {
 
         dynamicFeesHooks.setFee(123);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         vm.expectEmit(true, true, true, true, address(manager));
         emit Swap(key.toId(), address(swapRouter), -100, 98, 79228162514264329749955861424, 1e18, -1, 123);
 
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
         snapLastCall("update dynamic fee in before swap");
 
         assertEq(_fetchPoolLPFee(key), 123);
@@ -146,15 +142,13 @@ contract TestDynamicFees is Test, Deployers, GasSnapshot {
 
         dynamicFeesHooks.setFee(1000000);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         vm.expectEmit(true, true, true, true, address(manager));
         emit Swap(key.toId(), address(swapRouter), -100, 0, SQRT_PRICE_1_1, 1e18, -1, 1000000);
 
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
         assertEq(_fetchPoolLPFee(key), 1000000);
     }
@@ -164,15 +158,13 @@ contract TestDynamicFees is Test, Deployers, GasSnapshot {
 
         dynamicFeesHooks.setFee(500000);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         vm.expectEmit(true, true, true, true, address(manager));
         emit Swap(key.toId(), address(swapRouter), -100, 49, 79228162514264333632135824623, 1e18, -1, 500000);
 
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
         assertEq(_fetchPoolLPFee(key), 500000);
     }
@@ -264,15 +256,13 @@ contract TestDynamicFees is Test, Deployers, GasSnapshot {
         vm.prank(address(feeController));
         manager.setProtocolFee(key, 1000);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         vm.expectEmit(true, true, true, true, address(manager));
         emit Swap(key.toId(), address(swapRouter), -100, 98, 79228162514264329749955861424, 1e18, -1, 1122);
 
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
         assertEq(_fetchPoolLPFee(key), 123);
     }
@@ -316,15 +306,13 @@ contract TestDynamicFees is Test, Deployers, GasSnapshot {
         dynamicFeesNoHooks.forcePoolFeeUpdate(key, 123);
         assertEq(_fetchPoolLPFee(key), 123);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         vm.expectEmit(true, true, true, true, address(manager));
         emit Swap(key.toId(), address(swapRouter), -100, 98, 79228162514264329749955861424, 1e18, -1, 123);
 
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
         snapLastCall("swap with dynamic fee");
     }
 

--- a/test/DynamicReturnFees.t.sol
+++ b/test/DynamicReturnFees.t.sol
@@ -94,15 +94,13 @@ contract TestDynamicReturnFees is Test, Deployers, GasSnapshot {
 
         dynamicReturnFeesHook.setFee(123);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         vm.expectEmit(true, true, true, true, address(manager));
         emit Swap(key.toId(), address(swapRouter), -100, 98, 79228162514264329749955861424, 1e18, -1, 123);
 
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
         snapLastCall("swap with return dynamic fee");
 
         assertEq(_fetchPoolSwapFee(key), 0);

--- a/test/PoolManager.t.sol
+++ b/test/PoolManager.t.sol
@@ -547,9 +547,6 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
     }
 
     function test_swap_succeedsIfInitialized() public {
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
 
@@ -558,21 +555,15 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
             key.toId(), address(swapRouter), int128(-100), int128(98), 79228162514264329749955861424, 1e18, -1, 3000
         );
 
-        swapRouter.swap(key, swapParams, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
     }
 
     function test_swap_failsIfLocked() public {
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         vm.expectRevert(IPoolManager.ManagerLocked.selector);
-        manager.swap(key, swapParams, ZERO_BYTES);
+        manager.swap(key, SWAP_PARAMS, ZERO_BYTES);
     }
 
     function test_swap_succeedsWithNativeTokensIfInitialized() public {
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
 
@@ -588,7 +579,7 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
             3000
         );
 
-        swapRouter.swap{value: 100}(nativeKey, swapParams, testSettings, ZERO_BYTES);
+        swapRouter.swap{value: 100}(nativeKey, SWAP_PARAMS, testSettings, ZERO_BYTES);
     }
 
     function test_swap_succeedsWithHooksIfInitialized() public {
@@ -603,19 +594,16 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
 
         (key,) = initPoolAndAddLiquidity(currency0, currency1, IHooks(mockAddr), 3000, SQRT_PRICE_1_1, ZERO_BYTES);
 
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
 
-        BalanceDelta balanceDelta = swapRouter.swap(key, swapParams, testSettings, ZERO_BYTES);
+        BalanceDelta balanceDelta = swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
         bytes32 beforeSelector = MockHooks.beforeSwap.selector;
-        bytes memory beforeParams = abi.encode(address(swapRouter), key, swapParams, ZERO_BYTES);
+        bytes memory beforeParams = abi.encode(address(swapRouter), key, SWAP_PARAMS, ZERO_BYTES);
 
         bytes32 afterSelector = MockHooks.afterSwap.selector;
-        bytes memory afterParams = abi.encode(address(swapRouter), key, swapParams, balanceDelta, ZERO_BYTES);
+        bytes memory afterParams = abi.encode(address(swapRouter), key, SWAP_PARAMS, balanceDelta, ZERO_BYTES);
 
         assertEq(MockContract(mockAddr).timesCalledSelector(beforeSelector), 1);
         assertTrue(MockContract(mockAddr).calledWithSelector(beforeSelector, beforeParams));
@@ -676,38 +664,26 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
     }
 
     function test_swap_succeeds() public {
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
-        swapRouter.swap(key, swapParams, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
     }
 
     function test_swap_gas() public {
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
-        swapRouterNoChecks.swap(key, swapParams);
+        swapRouterNoChecks.swap(key, SWAP_PARAMS);
         snapLastCall("simple swap");
     }
 
     function test_swap_withNative_succeeds() public {
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
-        swapRouter.swap{value: 100}(nativeKey, swapParams, testSettings, ZERO_BYTES);
+        swapRouter.swap{value: 100}(nativeKey, SWAP_PARAMS, testSettings, ZERO_BYTES);
     }
 
     function test_swap_withNative_gas() public {
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
-        swapRouterNoChecks.swap{value: 100}(nativeKey, swapParams);
+        swapRouterNoChecks.swap{value: 100}(nativeKey, SWAP_PARAMS);
         snapLastCall("simple swap with native");
     }
 
@@ -720,15 +696,12 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
 
         (key,) = initPoolAndAddLiquidity(currency0, currency1, mockHooks, 3000, SQRT_PRICE_1_1, ZERO_BYTES);
 
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
-        swapRouter.swap(key, swapParams, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        swapParams =
+        IPoolManager.SwapParams memory swapParams =
             IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
         testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -737,15 +710,12 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
     }
 
     function test_swap_mint6909IfOutputNotTaken_gas() public {
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
 
         vm.expectEmit();
         emit Transfer(address(swapRouter), address(0), address(this), CurrencyLibrary.toId(currency1), 98);
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
         snapLastCall("swap mint output as 6909");
 
         uint256 erc6909Balance = manager.balanceOf(address(this), CurrencyLibrary.toId(currency1));
@@ -769,15 +739,12 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
     }
 
     function test_swap_burn6909AsInput_gas() public {
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
 
         vm.expectEmit();
         emit Transfer(address(swapRouter), address(0), address(this), CurrencyLibrary.toId(currency1), 98);
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
         uint256 erc6909Balance = manager.balanceOf(address(this), uint256(uint160(Currency.unwrap(currency1))));
         assertEq(erc6909Balance, 98);
@@ -786,7 +753,8 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
         manager.setOperator(address(swapRouter), true);
 
         // swap from currency1 to currency0 again, using 6909s as input tokens
-        params = IPoolManager.SwapParams({zeroForOne: false, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_4_1});
+        IPoolManager.SwapParams memory params =
+            IPoolManager.SwapParams({zeroForOne: false, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_4_1});
         testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: true});
 
         vm.expectEmit();
@@ -830,30 +798,26 @@ contract PoolManagerTest is Test, Deployers, GasSnapshot {
     }
 
     function test_swap_againstLiquidity_gas() public {
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
-        swapRouter.swap(key, params, testSettings, ZERO_BYTES);
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        params = IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        IPoolManager.SwapParams memory params =
+            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
 
         swapRouter.swap(key, params, testSettings, ZERO_BYTES);
         snapLastCall("swap against liquidity");
     }
 
     function test_swap_againstLiqWithNative_gas() public {
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
-        swapRouter.swap{value: 1 ether}(nativeKey, params, testSettings, ZERO_BYTES);
+        swapRouter.swap{value: 1 ether}(nativeKey, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        params = IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        IPoolManager.SwapParams memory params =
+            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
 
         swapRouter.swap{value: 1 ether}(nativeKey, params, testSettings, ZERO_BYTES);
         snapLastCall("swap against liquidity with native token");

--- a/test/SkipCallsTestHook.t.sol
+++ b/test/SkipCallsTestHook.t.sol
@@ -21,9 +21,6 @@ import {SkipCallsTestHook} from "../src/test/SkipCallsTestHook.sol";
 contract SkipCallsTest is Test, Deployers, GasSnapshot {
     using PoolIdLibrary for PoolKey;
 
-    IPoolManager.SwapParams swapParams =
-        IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
     PoolSwapTest.TestSettings testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
     function deploy(SkipCallsTestHook skipCallsTestHook) private {
@@ -144,10 +141,10 @@ contract SkipCallsTest is Test, Deployers, GasSnapshot {
         assertEq(skipCallsTestHook.counter(), 0);
 
         // swaps and increments counter
-        swapRouter.swap(key, swapParams, testSettings, abi.encode(address(this)));
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, abi.encode(address(this)));
         assertEq(skipCallsTestHook.counter(), 1);
         // swaps again and increments counter
-        swapRouter.swap(key, swapParams, testSettings, abi.encode(address(this)));
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, abi.encode(address(this)));
         assertEq(skipCallsTestHook.counter(), 2);
     }
 
@@ -161,7 +158,7 @@ contract SkipCallsTest is Test, Deployers, GasSnapshot {
         assertEq(skipCallsTestHook.counter(), 0);
 
         // swaps and increments counter
-        swapRouter.swap(key, swapParams, testSettings, abi.encode(address(this)));
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, abi.encode(address(this)));
         snapLastCall("swap skips hook call if hook is caller");
         assertEq(skipCallsTestHook.counter(), 1);
     }
@@ -176,10 +173,10 @@ contract SkipCallsTest is Test, Deployers, GasSnapshot {
         assertEq(skipCallsTestHook.counter(), 0);
 
         // swaps and increments counter
-        swapRouter.swap(key, swapParams, testSettings, abi.encode(address(this)));
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, abi.encode(address(this)));
         assertEq(skipCallsTestHook.counter(), 1);
         // swaps again and increments counter
-        swapRouter.swap(key, swapParams, testSettings, abi.encode(address(this)));
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, abi.encode(address(this)));
         assertEq(skipCallsTestHook.counter(), 2);
     }
 

--- a/test/Sync.t.sol
+++ b/test/Sync.t.sol
@@ -56,16 +56,13 @@ contract SyncTest is Test, Deployers, GasSnapshot {
     function test_settle_withStartingBalance() public noIsolate {
         assertGt(currency0.balanceOf(address(manager)), uint256(0));
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
-
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         // Sync has not been called.
         assertEq(manager.getReserves(currency0), 0);
 
-        swapRouter.swap(key, params, testSettings, new bytes(0));
+        swapRouter.swap(key, SWAP_PARAMS, testSettings, new bytes(0));
         (uint256 balanceCurrency0) = currency0.balanceOf(address(manager));
         assertEq(manager.getReserves(currency0), balanceCurrency0); // Reserves are up to date since settle was called.
     }

--- a/test/utils/Deployers.sol
+++ b/test/utils/Deployers.sol
@@ -51,6 +51,8 @@ contract Deployers {
         IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
     IPoolManager.ModifyLiquidityParams public REMOVE_LIQUIDITY_PARAMS =
         IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
+    IPoolManager.SwapParams public SWAP_PARAMS =
+        IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
     // Global variables
     Currency internal currency0;


### PR DESCRIPTION
Partially resolves Issue Uniswap#390

## Related Issue
Which issue does this pull request resolve?

Partially #390 

## Description of changes

Add `SWAP_PARAMS` to `Deployers.sol` and deprecate repeated `IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_RATIO_1_2})`