### PR TITLE
add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,10 +1,10 @@
 
 test *args: (test-forge args)
 build *args: (build-forge args)
-prep *args: fix (test args)
+prep *args: fix (test-forge args)
 
 
-test-forge *args: install-forge build-forge
+test-forge *args: build-forge
     forge test --isolate --no-match-path 'test/js-scripts/**/*' {{args}}
 
 

--- a/justfile
+++ b/justfile
@@ -1,15 +1,15 @@
-test: test-forge
-prep: fix
 
-test-mt TEST: install-forge build-forge
-    forge test --mt {{TEST}} --isolate --no-match-path 'test/js-scripts/**/*'
-
-test-forge: install-forge build-forge
-    forge test --isolate --no-match-path 'test/js-scripts/**/*' 
+test *args: (test-forge args)
+build *args: (build-forge args)
+prep *args: fix (test args)
 
 
-build-forge: install-forge
-    forge build --skip 'test/js-scripts/**/*'
+test-forge *args: install-forge build-forge
+    forge test --isolate --no-match-path 'test/js-scripts/**/*' {{args}}
+
+
+build-forge *args: install-forge
+    forge build --skip 'test/js-scripts/**/*' {{args}}
 
 install-forge:
     forge install

--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+test: test-forge
+prep: fix
+
+test-mt TEST: install-forge build-forge
+    forge test --mt {{TEST}} --isolate --no-match-path 'test/js-scripts/**/*'
+
+test-forge: install-forge build-forge
+    forge test --isolate --no-match-path 'test/js-scripts/**/*' 
+
+
+build-forge: install-forge
+    forge build --skip 'test/js-scripts/**/*'
+
+install-forge:
+    forge install
+
+fix:
+    forge fmt
+


### PR DESCRIPTION
## Related Issue
Which issue does this pull request resolve?

Commands are getting a little long to run tests with --isolate and soon with --no-match-path when we have the v3-sdk dependency. This documents that and allows you to run a few commands:

`just test` : Run all forge tests.

`just prep`: Runs linter.

`just test-mt {regex}`: Runs forge test --mt 

## Description of changes