### PR TITLE
add debug profile

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,4 +16,9 @@ runs = 10000
 [profile.ci.fuzz]
 runs = 100000
 
+[profile.debug]
+via_ir = false
+optimizer_runs = 200
+fuzz.runs = 100
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
## Related Issue

Which issue does this pull request resolve?

Now that we have via-ir enabled it takes longer to compile. This profile turns off via-ir if you want to quickly compile and test certain new features. Before PR-ing all tests should be run with the default profile.

To use 
`export FOUNDRY_PROFILE=debug`

## Description of changes
