### PR TITLE
fix warning

### DIFF
--- a/src/libraries/TickBitmap.sol
+++ b/src/libraries/TickBitmap.sol
@@ -43,13 +43,11 @@ library TickBitmap {
     /// @param tick The tick to flip
     /// @param tickSpacing The spacing between usable ticks
     function flipTick(mapping(int16 => uint256) storage self, int24 tick, int24 tickSpacing) internal {
-        /**
-         * Equivalent to the following Solidity:
-         *     if (tick % tickSpacing != 0) revert TickMisaligned(tick, tickSpacing);
-         *     (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
-         *     uint256 mask = 1 << bitPos;
-         *     self[wordPos] ^= mask;
-         */
+        // Equivalent to the following Solidity:
+        //     if (tick % tickSpacing != 0) revert TickMisaligned(tick, tickSpacing);
+        //     (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
+        //     uint256 mask = 1 << bitPos;
+        //     self[wordPos] ^= mask;
         assembly ("memory-safe") {
             // ensure that the tick is spaced
             if smod(tick, tickSpacing) {


### PR DESCRIPTION
Fixes the following warning that is currently coming on the latest commit.

```
Warning (6269): Unexpected NatSpec tag "notice" with value "Equivalent to the following Solidity:     if (tick % tickSpacing != 0) revert TickMisaligned(tick, tickSpacing);     (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);     uint256 mask = 1 << bitPos;     self[wordPos] ^= mask;" in inline assembly.
  --> lib/v4-core/src/libraries/TickBitmap.sol:53:9:
   |
53 |         assembly ("memory-safe") {
   |         ^ (Relevant source part starts here and spans across multiple lines).
```