### PR TITLE
reuse position key logic

### DIFF
--- a/src/libraries/Position.sol
+++ b/src/libraries/Position.sol
@@ -36,9 +36,21 @@ library Position {
         view
         returns (Info storage position)
     {
-        // positionKey = keccak256(abi.encodePacked(owner, tickLower, tickUpper, salt))
-        bytes32 positionKey;
+        position = self[key(owner, tickLower, tickUpper, salt)];
+    }
 
+    /// @notice Returns the key of a position, given an owner and position boundaries
+    /// @param owner The address of the position owner
+    /// @param tickLower The lower tick boundary of the position
+    /// @param tickUpper The upper tick boundary of the position
+    /// @param salt A unique value to differentiate between multiple positions in the same range
+    /// @return positionKey The key of the position
+    function key(address owner, int24 tickLower, int24 tickUpper, bytes32 salt)
+        internal
+        pure
+        returns (bytes32 positionKey)
+    {
+        // positionKey = keccak256(abi.encodePacked(owner, tickLower, tickUpper, salt))
         assembly ("memory-safe") {
             mstore(0x26, salt) // [0x26, 0x46)
             mstore(0x06, tickUpper) // [0x23, 0x26)
@@ -47,7 +59,6 @@ library Position {
             positionKey := keccak256(0x0c, 0x3a) // len is 58 bytes
             mstore(0x26, 0) // rewrite 0x26 to 0
         }
-        position = self[positionKey];
     }
 
     /// @notice Credits accumulated fees to a user's position

--- a/test/libraries/StateLibrary.t.sol
+++ b/test/libraries/StateLibrary.t.sol
@@ -486,10 +486,9 @@ contract StateLibraryTest is Test, Deployers, Fuzzers, GasSnapshot {
             key, IPoolManager.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
         );
 
-        bytes32 positionId =
-            keccak256(abi.encodePacked(address(modifyLiquidityRouter), int24(-60), int24(60), bytes32(0)));
-
-        uint128 liquidity = StateLibrary.getPositionLiquidity(manager, poolId, positionId);
+        uint128 liquidity = StateLibrary.getPositionLiquidity(
+            manager, poolId, address(modifyLiquidityRouter), int24(-60), int24(60), bytes32(0)
+        );
         snapLastCall("extsload getPositionLiquidity");
 
         assertEq(liquidity, 10_000 ether);
@@ -514,16 +513,14 @@ contract StateLibraryTest is Test, Deployers, Fuzzers, GasSnapshot {
         modifyLiquidityRouter.modifyLiquidity(key, _paramsA, ZERO_BYTES);
         modifyLiquidityRouter.modifyLiquidity(key, _paramsB, ZERO_BYTES);
 
-        bytes32 positionIdA = keccak256(
-            abi.encodePacked(address(modifyLiquidityRouter), _paramsA.tickLower, _paramsA.tickUpper, bytes32(0))
+        uint128 liquidityA = StateLibrary.getPositionLiquidity(
+            manager, poolId, address(modifyLiquidityRouter), _paramsA.tickLower, _paramsA.tickUpper, bytes32(0)
         );
-        uint128 liquidityA = StateLibrary.getPositionLiquidity(manager, poolId, positionIdA);
         assertEq(liquidityA, uint128(uint256(_paramsA.liquidityDelta)));
 
-        bytes32 positionIdB = keccak256(
-            abi.encodePacked(address(modifyLiquidityRouter), _paramsB.tickLower, _paramsB.tickUpper, bytes32(0))
+        uint128 liquidityB = StateLibrary.getPositionLiquidity(
+            manager, poolId, address(modifyLiquidityRouter), _paramsB.tickLower, _paramsB.tickUpper, bytes32(0)
         );
-        uint128 liquidityB = StateLibrary.getPositionLiquidity(manager, poolId, positionIdB);
         assertEq(liquidityB, uint128(uint256(_paramsB.liquidityDelta)));
     }
 }


### PR DESCRIPTION
This PR abstracts the computation of position key. I wanted to use `StateLibrary.getPositionLiquidity` which asks for `positionId` from the dev. Instead of copy pasting the hashing logic, it would be cool to import Position library and just do `Position.key(...)`.