### PR TITLE
Clarify comment transient storage Solidity and Assembly

### DIFF
--- a/src/libraries/Lock.sol
+++ b/src/libraries/Lock.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.20;
 import {IHooks} from "../interfaces/IHooks.sol";
 
 /// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
-/// TODO: This library can be deleted when we have the transient keyword support in solidity.
+/// TODO: This library can be deleted when we have transient storage commands in Solidity 
+/// instead of Assembly for tload(key) and tstore(key,value) documented here: https://www.evm.codes/
 library Lock {
     // The slot holding the unlocked state, transiently. bytes32(uint256(keccak256("Unlocked")) - 1)
     bytes32 constant IS_UNLOCKED_SLOT = 0xc090fc4683624cfc3884e9d8de5eca132f2d0ec062aff75d43c0465d5ceeab23;


### PR DESCRIPTION
## Description of changes

Transient storage opcodes are known now after Ethereum's Dencun Fork Update.
Will library Lock.sol still be deleted based on the contract's comments? 
