### PR TITLE
OZ N09: removed unused custom error

### DIFF
--- a/src/libraries/Pool.sol
+++ b/src/libraries/Pool.sol
@@ -42,10 +42,6 @@ library Pool {
     /// @notice For the tick spacing, the tick has too much liquidity
     error TickLiquidityOverflow(int24 tick);
 
-    /// @notice Thrown when interacting with an uninitialized tick that must be initialized
-    /// @param tick The uninitialized tick
-    error TickNotInitialized(int24 tick);
-
     /// @notice Thrown when trying to initialize an already initialized pool
     error PoolAlreadyInitialized();
 


### PR DESCRIPTION
## Description of changes

Remove unused custom error `TickNotInitialized` from `Pool.sol`.