### PR TITLE
OZ N01, ABDK, Standardise pragma versions

### DIFF
--- a/src/ERC6909.sol
+++ b/src/ERC6909.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.0;
 
 import {IERC6909Claims} from "./interfaces/external/IERC6909Claims.sol";
 

--- a/src/ERC6909Claims.sol
+++ b/src/ERC6909Claims.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.0;
 
 import {ERC6909} from "./ERC6909.sol";
 

--- a/src/Extsload.sol
+++ b/src/Extsload.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.0;
+pragma solidity ^0.8.0;
 
 import {IExtsload} from "./interfaces/IExtsload.sol";
 

--- a/src/Exttload.sol
+++ b/src/Exttload.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.24;
+pragma solidity ^0.8.24;
 
 import {IExttload} from "./interfaces/IExttload.sol";
 

--- a/src/NoDelegateCall.sol
+++ b/src/NoDelegateCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {CustomRevert} from "./libraries/CustomRevert.sol";
 

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.24;
+pragma solidity 0.8.26;
 
 import {Hooks} from "./libraries/Hooks.sol";
 import {Pool} from "./libraries/Pool.sol";

--- a/src/ProtocolFees.sol
+++ b/src/ProtocolFees.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.0;
 
 import {Currency} from "./types/Currency.sol";
 import {IProtocolFeeController} from "./interfaces/IProtocolFeeController.sol";

--- a/src/interfaces/IExtsload.sol
+++ b/src/interfaces/IExtsload.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.0;
+pragma solidity ^0.8.0;
 
 interface IExtsload {
     /// @notice Called by external contracts to access granular pool state

--- a/src/interfaces/IExttload.sol
+++ b/src/interfaces/IExttload.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.24;
+pragma solidity ^0.8.24;
 
 interface IExttload {
     /// @notice Called by external contracts to access transient storage of the contract

--- a/src/interfaces/IHooks.sol
+++ b/src/interfaces/IHooks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.0;
 
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";

--- a/src/interfaces/IProtocolFeeController.sol
+++ b/src/interfaces/IProtocolFeeController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {PoolKey} from "../types/PoolKey.sol";
 

--- a/src/interfaces/callback/IUnlockCallback.sol
+++ b/src/interfaces/callback/IUnlockCallback.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 interface IUnlockCallback {
     /// @notice Called by the pool manager on `msg.sender` when the manager is unlocked

--- a/src/interfaces/external/IERC20Minimal.sol
+++ b/src/interfaces/external/IERC20Minimal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title Minimal ERC20 interface for Uniswap
 /// @notice Contains a subset of the full ERC20 interface that is used in Uniswap V3

--- a/src/interfaces/external/IERC6909Claims.sol
+++ b/src/interfaces/external/IERC6909Claims.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.0;
 
 interface IERC6909Claims {
     /// @notice Owner balance of an id.

--- a/src/libraries/BitMath.sol
+++ b/src/libraries/BitMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title BitMath
 /// @dev This library provides functionality for computing bit properties of an unsigned integer

--- a/src/libraries/CurrencyDelta.sol
+++ b/src/libraries/CurrencyDelta.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Currency} from "../types/Currency.sol";
 

--- a/src/libraries/CustomRevert.sol
+++ b/src/libraries/CustomRevert.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.4;
+pragma solidity ^0.8.0;
 
 /// @title Library for reverting with custom errors efficiently
 /// @notice Contains functions for reverting with custom errors with different argument types efficiently

--- a/src/libraries/FixedPoint128.sol
+++ b/src/libraries/FixedPoint128.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title FixedPoint128
 /// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)

--- a/src/libraries/FixedPoint96.sol
+++ b/src/libraries/FixedPoint96.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title FixedPoint96
 /// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)

--- a/src/libraries/FullMath.sol
+++ b/src/libraries/FullMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title Contains 512-bit math functions
 /// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision

--- a/src/libraries/Hooks.sol
+++ b/src/libraries/Hooks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.0;
 
 import {PoolKey} from "../types/PoolKey.sol";
 import {IHooks} from "../interfaces/IHooks.sol";

--- a/src/libraries/LPFeeLibrary.sol
+++ b/src/libraries/LPFeeLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {PoolKey} from "../types/PoolKey.sol";
 import {CustomRevert} from "./CustomRevert.sol";

--- a/src/libraries/LiquidityMath.sol
+++ b/src/libraries/LiquidityMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title Math library for liquidity
 library LiquidityMath {

--- a/src/libraries/Lock.sol
+++ b/src/libraries/Lock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {IHooks} from "../interfaces/IHooks.sol";
 

--- a/src/libraries/NonZeroDeltaCount.sol
+++ b/src/libraries/NonZeroDeltaCount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {IHooks} from "../interfaces/IHooks.sol";
 

--- a/src/libraries/ParseBytes.sol
+++ b/src/libraries/ParseBytes.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @notice Parses bytes returned from hooks and the byte selector used to check return selectors from hooks.
 /// @dev parseSelector also is used to parse the expected selector

--- a/src/libraries/Pool.sol
+++ b/src/libraries/Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {SafeCast} from "./SafeCast.sol";
 import {TickBitmap} from "./TickBitmap.sol";

--- a/src/libraries/Position.sol
+++ b/src/libraries/Position.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {FullMath} from "./FullMath.sol";
 import {FixedPoint128} from "./FixedPoint128.sol";

--- a/src/libraries/ProtocolFeeLibrary.sol
+++ b/src/libraries/ProtocolFeeLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 library ProtocolFeeLibrary {
     // Max protocol fee is 0.1% (1000 pips)

--- a/src/libraries/Reserves.sol
+++ b/src/libraries/Reserves.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {Currency} from "../types/Currency.sol";
 import {CustomRevert} from "./CustomRevert.sol";

--- a/src/libraries/SafeCast.sol
+++ b/src/libraries/SafeCast.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title Safe casting methods
 /// @notice Contains methods for safely casting between types

--- a/src/libraries/SqrtPriceMath.sol
+++ b/src/libraries/SqrtPriceMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {SafeCast} from "./SafeCast.sol";
 

--- a/src/libraries/StateLibrary.sol
+++ b/src/libraries/StateLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.0;
 
 import {PoolId} from "../types/PoolId.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";

--- a/src/libraries/SwapMath.sol
+++ b/src/libraries/SwapMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {FullMath} from "./FullMath.sol";
 import {SqrtPriceMath} from "./SqrtPriceMath.sol";

--- a/src/libraries/TickBitmap.sol
+++ b/src/libraries/TickBitmap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {BitMath} from "./BitMath.sol";
 

--- a/src/libraries/TickMath.sol
+++ b/src/libraries/TickMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title Math library for computing sqrt prices from ticks and vice versa
 /// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers. Supports

--- a/src/libraries/TransientStateLibrary.sol
+++ b/src/libraries/TransientStateLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
+pragma solidity ^0.8.24;
 
 import {PoolId} from "../types/PoolId.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";

--- a/src/libraries/UnsafeMath.sol
+++ b/src/libraries/UnsafeMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /// @title Math functions that do not check inputs or outputs
 /// @notice Contains methods that perform common math functions but do not do any overflow or underflow checks

--- a/src/types/BalanceDelta.sol
+++ b/src/types/BalanceDelta.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {SafeCast} from "../libraries/SafeCast.sol";
 

--- a/src/types/BeforeSwapDelta.sol
+++ b/src/types/BeforeSwapDelta.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {BalanceDelta} from "./BalanceDelta.sol";
 

--- a/src/types/Currency.sol
+++ b/src/types/Currency.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {IERC20Minimal} from "../interfaces/external/IERC20Minimal.sol";
 

--- a/src/types/PoolId.sol
+++ b/src/types/PoolId.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {PoolKey} from "./PoolKey.sol";
 

--- a/src/types/PoolKey.sol
+++ b/src/types/PoolKey.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.0;
 
 import {Currency} from "./Currency.sol";
 import {IHooks} from "../interfaces/IHooks.sol";

--- a/src/types/Slot0.sol
+++ b/src/types/Slot0.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Slot0 is a packed version of solidity structure.


### PR DESCRIPTION
- All inherited contracts/libraries/interfaces are ^0.8.0 to allow integrators flexibility
- Above files that rely on transient storage are ^0.8.24
- Removed the use of `>=` to prevent problems with future major releases
- Hardcoded the version of the PoolManager to be 0.8.26 as this is the actual contract that will be deployed. This will fix the version for all contracts when we deploy to 0.8.26.