### PR TITLE
Rename currency settler util contract

### DIFF
--- a/src/test/CustomCurveHook.sol
+++ b/src/test/CustomCurveHook.sol
@@ -9,14 +9,14 @@ import {PoolKey} from "../types/PoolKey.sol";
 import {BeforeSwapDelta, toBeforeSwapDelta} from "../types/BeforeSwapDelta.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 import {BaseTestHooks} from "./BaseTestHooks.sol";
 import {IERC20Minimal} from "../interfaces/external/IERC20Minimal.sol";
 import {Currency} from "../types/Currency.sol";
 
 contract CustomCurveHook is BaseTestHooks {
     using Hooks for IHooks;
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
 
     error AddLiquidityDirectToHook();
 

--- a/src/test/DeltaReturningHook.sol
+++ b/src/test/DeltaReturningHook.sol
@@ -5,7 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {SafeCast} from "../libraries/SafeCast.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, toBalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -16,7 +16,7 @@ import {BeforeSwapDelta, toBeforeSwapDelta} from "../types/BeforeSwapDelta.sol";
 
 contract DeltaReturningHook is BaseTestHooks {
     using Hooks for IHooks;
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
 
     IPoolManager immutable manager;
 

--- a/src/test/PoolClaimsTest.sol
+++ b/src/test/PoolClaimsTest.sol
@@ -7,10 +7,10 @@ import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
 import {SafeCast} from "../libraries/SafeCast.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 
 contract PoolClaimsTest is PoolTestBase {
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using SafeCast for uint256;
 
     constructor(IPoolManager _manager) PoolTestBase(_manager) {}

--- a/src/test/PoolDonateTest.sol
+++ b/src/test/PoolDonateTest.sol
@@ -8,10 +8,10 @@ import {BalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 
 contract PoolDonateTest is PoolTestBase {
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using Hooks for IHooks;
 
     constructor(IPoolManager _manager) PoolTestBase(_manager) {}

--- a/src/test/PoolModifyLiquidityTest.sol
+++ b/src/test/PoolModifyLiquidityTest.sol
@@ -10,11 +10,11 @@ import {PoolTestBase} from "./PoolTestBase.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
 import {LPFeeLibrary} from "../libraries/LPFeeLibrary.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 import {StateLibrary} from "../libraries/StateLibrary.sol";
 
 contract PoolModifyLiquidityTest is PoolTestBase {
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using Hooks for IHooks;
     using LPFeeLibrary for uint24;
     using PoolIdLibrary for PoolKey;

--- a/src/test/PoolModifyLiquidityTestNoChecks.sol
+++ b/src/test/PoolModifyLiquidityTestNoChecks.sol
@@ -10,11 +10,11 @@ import {PoolTestBase} from "./PoolTestBase.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
 import {LPFeeLibrary} from "../libraries/LPFeeLibrary.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 import {Constants} from "../../test/utils/Constants.sol";
 
 contract PoolModifyLiquidityTestNoChecks is PoolTestBase {
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using Hooks for IHooks;
     using LPFeeLibrary for uint24;
     using PoolIdLibrary for PoolKey;

--- a/src/test/PoolNestedActionsTest.sol
+++ b/src/test/PoolNestedActionsTest.sol
@@ -10,7 +10,7 @@ import {Test} from "forge-std/Test.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
 import {PoolId, PoolIdLibrary} from "../types/PoolId.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 import {StateLibrary} from "../libraries/StateLibrary.sol";
 import {TransientStateLibrary} from "../libraries/TransientStateLibrary.sol";
 
@@ -66,7 +66,7 @@ contract PoolNestedActionsTest is Test, IUnlockCallback {
 contract NestedActionExecutor is Test, PoolTestBase {
     using StateLibrary for IPoolManager;
     using TransientStateLibrary for IPoolManager;
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using PoolIdLibrary for PoolKey;
 
     PoolKey internal key;

--- a/src/test/PoolSwapTest.sol
+++ b/src/test/PoolSwapTest.sol
@@ -8,10 +8,10 @@ import {PoolKey} from "../types/PoolKey.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 
 contract PoolSwapTest is PoolTestBase {
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using Hooks for IHooks;
 
     constructor(IPoolManager _manager) PoolTestBase(_manager) {}

--- a/src/test/PoolTakeTest.sol
+++ b/src/test/PoolTakeTest.sol
@@ -6,10 +6,10 @@ import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
 import {SafeCast} from "../libraries/SafeCast.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 
 contract PoolTakeTest is PoolTestBase {
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using SafeCast for uint256;
 
     constructor(IPoolManager _manager) PoolTestBase(_manager) {}

--- a/src/test/SkipCallsTestHook.sol
+++ b/src/test/SkipCallsTestHook.sol
@@ -13,13 +13,13 @@ import {Currency} from "../types/Currency.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
 import {Constants} from "../../test/utils/Constants.sol";
 import {Test} from "forge-std/Test.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 import {StateLibrary} from "../libraries/StateLibrary.sol";
 import {TransientStateLibrary} from "../libraries/TransientStateLibrary.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
 
 contract SkipCallsTestHook is BaseTestHooks, Test {
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using PoolIdLibrary for PoolKey;
     using Hooks for IHooks;
     using StateLibrary for IPoolManager;

--- a/src/test/SwapRouterNoChecks.sol
+++ b/src/test/SwapRouterNoChecks.sol
@@ -8,10 +8,10 @@ import {PoolKey} from "../types/PoolKey.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
-import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
+import {CurrencySettlerTestUtil} from "../../test/utils/CurrencySettlerTestUtil.sol";
 
 contract SwapRouterNoChecks is PoolTestBase {
-    using CurrencySettler for Currency;
+    using CurrencySettlerTestUtil for Currency;
     using Hooks for IHooks;
 
     constructor(IPoolManager _manager) PoolTestBase(_manager) {}

--- a/test/utils/CurrencySettlerTestUtil.sol
+++ b/test/utils/CurrencySettlerTestUtil.sol
@@ -9,7 +9,9 @@ import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
 /// To settle a positive delta (a credit to the user), a user may take or mint.
 /// To settle a negative delta (a debt on the user), a user make transfer or burn to pay off a debt.
 /// @dev Note that sync() is called before any erc-20 transfer in `settle`.
-library CurrencySettler {
+/// @dev THIS CONTRACT IS NOT SECURE, IT IS FOR TESTING PURPOSES, DO NOT USE IT IN PROD
+/// For an equivalent library, see v4-periphery/contracts/libraries/CurrencySettlerTestUtil.sol
+library CurrencySettlerTestUtil {
     /// @notice Settle (pay) a currency to the PoolManager
     /// @param currency Currency to settle
     /// @param manager IPoolManager to settle to


### PR DESCRIPTION
## Related Issue

Which issue does this pull request resolve?

This contract is not secure and is just a test util. Lets name it as such, and put a better version in periphery for real contracts.