### PR TITLE
Update openzeppelin-contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,9 @@
 [submodule "lib/forge-gas-snapshot"]
 	path = lib/forge-gas-snapshot
 	url = https://github.com/marktoda/forge-gas-snapshot
-[submodule "lib/openzeppelin-contracts"]
-	path = lib/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-	tag = v4.4.2
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/src/test/MockContract.sol
+++ b/src/test/MockContract.sol
@@ -50,7 +50,7 @@ contract MockContract is Proxy {
 
     function _fallback() internal override {
         _beforeFallback();
-        _delegate(_implementation());
+        super._fallback();
     }
 
     receive() external payable {}

--- a/src/test/MockContract.sol
+++ b/src/test/MockContract.sol
@@ -41,10 +41,17 @@ contract MockContract is Proxy {
     }
 
     /// @notice Captures calls by selector
-    function _beforeFallback() internal override {
+    function _beforeFallback() internal {
         bytes32 selector = bytes32(msg.data[:5]);
         bytes memory params = msg.data[5:];
         calls[selector]++;
         callParams[selector][params]++;
     }
+
+    function _fallback() internal override {
+        _beforeFallback();
+        _delegate(_implementation());
+    }
+
+    receive() external payable {}
 }


### PR DESCRIPTION
## Related Issue

Closes #801 

## Description of changes

Updated openzeppelin to v5.0.2. With periphery using core's dependencies (instead of maintaining its own), the now official EIP721.sol will be useful for our ERC721Permit implementation