### PR TITLE
calculate positionKey with a helper function

### DIFF
--- a/src/libraries/Position.sol
+++ b/src/libraries/Position.sol
@@ -37,8 +37,20 @@ library Position {
         returns (Info storage position)
     {
         // positionKey = keccak256(abi.encodePacked(owner, tickLower, tickUpper, salt))
-        bytes32 positionKey;
+        bytes32 positionKey = calculatePositionKey(owner, tickLower, tickUpper, salt);
+        position = self[positionKey];
+    }
 
+    /// @notice A helper function to calculate the position key
+    /// @param owner The address of the position owner
+    /// @param tickLower the lower tick boundary of the position
+    /// @param tickUpper the upper tick boundary of the position
+    /// @param salt A unique value to differentiate between multiple positions in the same range, by the same owner. Passed in by the caller.
+    function calculatePositionKey(address owner, int24 tickLower, int24 tickUpper, bytes32 salt)
+        internal
+        pure
+        returns (bytes32 positionKey)
+    {
         assembly ("memory-safe") {
             let fmp := mload(0x40)
             mstore(add(fmp, 0x26), salt) // [0x26, 0x46)
@@ -52,7 +64,6 @@ library Position {
             mstore(add(fmp, 0x20), 0) // fmp+0x20 held tickLower, tickUpper, salt
             mstore(fmp, 0) // fmp held owner
         }
-        position = self[positionKey];
     }
 
     /// @notice Credits accumulated fees to a user's position

--- a/src/libraries/Position.sol
+++ b/src/libraries/Position.sol
@@ -36,7 +36,6 @@ library Position {
         view
         returns (Info storage position)
     {
-        // positionKey = keccak256(abi.encodePacked(owner, tickLower, tickUpper, salt))
         bytes32 positionKey = calculatePositionKey(owner, tickLower, tickUpper, salt);
         position = self[positionKey];
     }
@@ -51,6 +50,7 @@ library Position {
         pure
         returns (bytes32 positionKey)
     {
+        // positionKey = keccak256(abi.encodePacked(owner, tickLower, tickUpper, salt))
         assembly ("memory-safe") {
             let fmp := mload(0x40)
             mstore(add(fmp, 0x26), salt) // [0x26, 0x46)

--- a/test/libraries/Position.t.sol
+++ b/test/libraries/Position.t.sol
@@ -71,4 +71,12 @@ contract PositionTest is Test {
         assertEq(position.feeGrowthInside0LastX128, newFeeGrowthInside0X128);
         assertEq(position.feeGrowthInside1LastX128, newFeeGrowthInside1X128);
     }
+
+    function test_fuzz_calculatePositionKey(address owner, int24 tickLower, int24 tickUpper, bytes32 salt)
+        public
+        pure
+    {
+        bytes32 positionKey = Position.calculatePositionKey(owner, tickLower, tickUpper, salt);
+        assertEq(positionKey, keccak256(abi.encodePacked(owner, tickLower, tickUpper, salt)));
+    }
 }


### PR DESCRIPTION
## Related Issue

PositionManager often needs to calculate the positionKey (positionId). Instead of rewriting code, we can expose this calculation in core. Likely other integrations will want something similar.

Which issue does this pull request resolve?

## Description of changes
