### PR TITLE
chore: pin-to-sha-hash

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@8f1998e9878d786675189ef566a2e4bf24869773
         with:
           version: nightly
       - name: Run Forge build


### PR DESCRIPTION
## Related Issue

[Which issue does this pull request resolve?](https://linear.app/uniswap/issue/PROTO-412/pin-to-sha-hash-instead-of-version-for-github-action)

## Description of changes
Simply pins the version to a hash rather than a version number 