### PR TITLE
SafeCast int128 to uint128

### DIFF
--- a/src/libraries/SafeCast.sol
+++ b/src/libraries/SafeCast.sol
@@ -26,6 +26,14 @@ library SafeCast {
         if (x != y) SafeCastOverflow.selector.revertWith();
     }
 
+    /// @notice Cast a int128 to a uint128, revert on overflow or underflow
+    /// @param x The int128 to be casted
+    /// @return y The casted integer, now type uint128
+    function toUint128(int128 x) internal pure returns (uint128 y) {
+        if (x < 0) SafeCastOverflow.selector.revertWith();
+        y = uint128(x);
+    }
+
     /// @notice Cast a int256 to a int128, revert on overflow or underflow
     /// @param x The int256 to be downcasted
     /// @return y The downcasted integer, now type int128

--- a/test/libraries/SafeCast.t.sol
+++ b/test/libraries/SafeCast.t.sol
@@ -22,7 +22,7 @@ contract SafeCastTest is Test {
         SafeCast.toUint160(type(uint160).max + uint256(1));
     }
 
-    function test_fuzz_toUint128(uint256 x) public {
+    function test_fuzz_toUint128_fromUint256(uint256 x) public {
         if (x <= type(uint128).max) {
             assertEq(uint256(SafeCast.toUint128(x)), x);
         } else {
@@ -31,7 +31,7 @@ contract SafeCastTest is Test {
         }
     }
 
-    function test_fuzz_toUint128(int128 x) public {
+    function test_fuzz_toUint128_fromInt128(int128 x) public {
         if (x < 0) {
             vm.expectRevert(SafeCast.SafeCastOverflow.selector);
             SafeCast.toUint128(x);
@@ -40,7 +40,7 @@ contract SafeCastTest is Test {
         }
     }
 
-    function test_toUint128() public {
+    function test_toUint128_fromUint256() public {
         assertEq(uint256(SafeCast.toUint128(uint256(0))), 0);
         assertEq(uint256(SafeCast.toUint128(type(uint128).max)), type(uint128).max);
         vm.expectRevert(SafeCast.SafeCastOverflow.selector);

--- a/test/libraries/SafeCast.t.sol
+++ b/test/libraries/SafeCast.t.sol
@@ -31,8 +31,17 @@ contract SafeCastTest is Test {
         }
     }
 
+    function test_fuzz_toUint128(int128 x) public {
+        if (x < 0) {
+            vm.expectRevert(SafeCast.SafeCastOverflow.selector);
+            SafeCast.toUint128(x);
+        } else {
+            assertEq(SafeCast.toUint128(x), uint128(x));
+        }
+    }
+
     function test_toUint128() public {
-        assertEq(uint256(SafeCast.toUint128(0)), 0);
+        assertEq(uint256(SafeCast.toUint128(uint256(0))), 0);
         assertEq(uint256(SafeCast.toUint128(type(uint128).max)), type(uint128).max);
         vm.expectRevert(SafeCast.SafeCastOverflow.selector);
         SafeCast.toUint128(type(uint128).max + uint256(1));


### PR DESCRIPTION
## Related Issue

v4-periphery has a need to convert int128 to uint128, and has a temporary library:

https://github.com/Uniswap/v4-periphery/blob/main/src/libraries/SafeCast.sol

## Description of changes

Added int128 -> uint128 safecasting