### PR TITLE
Add 'Tests' section in 'Contributing' file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,9 @@ All contributions must follow the below standards. Maintainers will close out PR
 
 `forge build` to get contract artifacts and dependencies for forge
 
-`forge test --isolate` to run forge tests and update snapshots
+## Tests
+
+`forge test --isolate` to run forge tests and update snapshots 
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Related Issue

The link to the forge  test + snapshot command points to a missing section.

## Description of changes

Added a 'Tests' section and moved the forge command from 'Setup' section there.