### PR TITLE
NoDelegateCall.sol MIT License

### DIFF
--- a/src/NoDelegateCall.sol
+++ b/src/NoDelegateCall.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {CustomRevert} from "./libraries/CustomRevert.sol";


### PR DESCRIPTION
## Description of changes

Changes NoDelegateCall.sol from BUSL-1.1 to MIT license.
