### PR TITLE
Update Lock.sol in Solidity 0.8.28 for transient variable support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ optimizer_runs = 44444444
 via_ir = true
 ffi = true
 fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}, { access = "read", path = "./out"}, {access = "read", path = "./test/bin"}]
-solc = "0.8.26"
+solc = "0.8.28"
 evm_version = "cancun"
 gas_limit = "300000000"
 

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity 0.8.28;
 
 import {Hooks} from "./libraries/Hooks.sol";
 import {Pool} from "./libraries/Pool.sol";

--- a/src/libraries/Lock.sol
+++ b/src/libraries/Lock.sol
@@ -1,28 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.24;
+pragma solidity 0.8.28;
 
-/// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
-/// TODO: This library can be deleted when we have the transient keyword support in solidity.
-library Lock {
-    // The slot holding the unlocked state, transiently. bytes32(uint256(keccak256("Unlocked")) - 1)
-    bytes32 internal constant IS_UNLOCKED_SLOT = 0xc090fc4683624cfc3884e9d8de5eca132f2d0ec062aff75d43c0465d5ceeab23;
+contract Lock {
+    bool internal transient IS_UNLOCKED_SLOT;
 
     function unlock() internal {
-        assembly ("memory-safe") {
-            // unlock
-            tstore(IS_UNLOCKED_SLOT, true)
-        }
+        IS_UNLOCKED_SLOT = true;
     }
 
     function lock() internal {
-        assembly ("memory-safe") {
-            tstore(IS_UNLOCKED_SLOT, false)
-        }
+        IS_UNLOCKED_SLOT = false;
     }
 
     function isUnlocked() internal view returns (bool unlocked) {
-        assembly ("memory-safe") {
-            unlocked := tload(IS_UNLOCKED_SLOT)
-        }
+        unlocked = IS_UNLOCKED_SLOT;
     }
 }


### PR DESCRIPTION
## Related Issue

From Lock.sol:

```solidity
/// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
/// TODO: This library can be deleted when we have the transient keyword support in solidity.
```

## Description of changes

Update Lock.sol in Solidity 0.8.28 for transient variable support

We can now write Solidity transient storage variables as shown in this example:
```solidity
// SPDX-License-Identifier: BUSL-1.1
pragma solidity 0.8.28;

contract Lock {
    bool internal transient IS_UNLOCKED_SLOT;

    function unlock() internal {
        IS_UNLOCKED_SLOT = true;
    }

    function lock() internal {
        IS_UNLOCKED_SLOT = false;
    }

    function isUnlocked() internal view returns (bool unlocked) {
        unlocked = IS_UNLOCKED_SLOT;
    }
}
```

Solidity 0.8.28 documentation:

https://docs.soliditylang.org/en/v0.8.28/
