### PR TITLE
store PoolKey in Pool.State

### DIFF
--- a/snapshots/PoolManagerInitializeTest.json
+++ b/snapshots/PoolManagerInitializeTest.json
@@ -1,3 +1,3 @@
 {
-  "initialize": "51532"
+  "initialize": "98285"
 }

--- a/snapshots/PoolManagerTest.json
+++ b/snapshots/PoolManagerTest.json
@@ -5,7 +5,7 @@
   "donate gas with 2 tokens": "145510",
   "erc20 collect protocol fees": "57500",
   "native collect protocol fees": "59643",
-  "poolManager bytecode size": "24050",
+  "poolManager bytecode size": "24370",
   "removeLiquidity with empty hook": "130613",
   "removeLiquidity with native token": "112523",
   "simple addLiquidity": "161276",

--- a/snapshots/StateLibraryTest.json
+++ b/snapshots/StateLibraryTest.json
@@ -2,6 +2,7 @@
   "extsload getFeeGrowthGlobals": "774",
   "extsload getFeeGrowthInside": "375",
   "extsload getLiquidity": "375",
+  "extsload getPoolKey": "6949",
   "extsload getPositionInfo": "949",
   "extsload getPositionLiquidity": "375",
   "extsload getSlot0": "375",

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -125,13 +125,11 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
         }
         if (!key.hooks.isValidHookAddress(key.fee)) Hooks.HookAddressNotValid.selector.revertWith(address(key.hooks));
 
-        uint24 lpFee = key.fee.getInitialLPFee();
-
         key.hooks.beforeInitialize(key, sqrtPriceX96);
 
         PoolId id = key.toId();
 
-        tick = _pools[id].initialize(sqrtPriceX96, lpFee);
+        tick = _pools[id].initialize(key, sqrtPriceX96);
 
         // event is emitted before the afterInitialize call to ensure events are always emitted in order
         // emit all details of a pool key. poolkeys are not saved in storage and must always be provided by the caller

--- a/src/test/ProxyPoolManager.sol
+++ b/src/test/ProxyPoolManager.sol
@@ -79,13 +79,11 @@ contract ProxyPoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909
         }
         if (!key.hooks.isValidHookAddress(key.fee)) Hooks.HookAddressNotValid.selector.revertWith(address(key.hooks));
 
-        uint24 lpFee = key.fee.getInitialLPFee();
-
         key.hooks.beforeInitialize(key, sqrtPriceX96);
 
         PoolId id = key.toId();
 
-        tick = _pools[id].initialize(sqrtPriceX96, lpFee);
+        tick = _pools[id].initialize(key, sqrtPriceX96);
 
         key.hooks.afterInitialize(key, sqrtPriceX96, tick);
 


### PR DESCRIPTION
Integrators need the PoolKey to interact with a pool. Currently, this is not stored on-chain. In order to obtain this data for a specific PoolId, one needs to either:

- Search for the Initialize event, probably over a very large range of blocks.
- Find a transaction with a swap/modifyLiquidity call, trace it, find the correct frame, and decode the calldata into PoolKey.

Both methods are quite complex. This PR proposes to store the PoolKey in Pool.State during initialization and make it easily accessible for integrators and users with a new getPoolKey function in StateLibrary.