### PR TITLE
standardize the init code hash

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}, { access
 solc = "0.8.26"
 evm_version = "cancun"
 gas_limit = "300000000"
+bytecode_hash = "none"
 
 [profile.default.fuzz]
 runs = 1000


### PR DESCRIPTION
## Related Issue

The init code hash of the `PoolManager.sol` in v4-core and v4-periphery was different because of different paths inside the metadata. This PR will disable the inclusion of the metadata hash inside of compiled bytecode.

## Description of changes

Setting `bytecode_hash = "none"` in the `foundry.toml`.