### PR TITLE
Update Slot0.t.sol so that masks are inlined (Issue #797)

### DIFF
--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -224,6 +224,13 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
     /// If the upper 12 bytes are not 0, they will be 0-ed out
     function burn(address from, uint256 id, uint256 amount) external;
 
+    /// @notice Emitted when a dynamic LP fee is updated
+    /// @param poolKey The pool key for the pool whose LP fee was updated
+    /// @param newDynamicLPFee The new dynamic LP fee value
+    /// @param updater The address that initiated the update
+    event DynamicLPFeeUpdated(PoolKey indexed poolKey, uint24 newDynamicLPFee, address indexed updater);
+
+
     /// @notice Updates the pools lp fees for the a pool that has enabled dynamic lp fees.
     /// @dev A swap fee totaling MAX_SWAP_FEE (100%) makes exact output swaps impossible since the input is entirely consumed by the fee
     /// @param key The key of the pool to update dynamic LP fees for

--- a/test/types/Slot0.t.sol
+++ b/test/types/Slot0.t.sol
@@ -6,28 +6,36 @@ import {Slot0, Slot0Library} from "../../src/types/Slot0.sol";
 
 contract TestSlot0 is Test {
     function test_slot0_constants_masks() public pure {
-        assertEq(Slot0Library.MASK_160_BITS, type(uint160).max);
-        assertEq(Slot0Library.MASK_24_BITS, type(uint24).max);
+        // verify that the inline masks match the expected maximum values for their types
+        assertEq(uint160(~uint256(0) >> (256 - 160)), type(uint160).max);
+        assertEq(uint24(~uint256(0) >> (256 - 24)), type(uint24).max);
     }
 
     function test_fuzz_slot0_pack_unpack(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)
         public
         pure
     {
-        // pack starting from "lowest" field
-        Slot0 _slot0 = Slot0.wrap(bytes32(0)).setSqrtPriceX96(sqrtPriceX96).setTick(tick).setProtocolFee(protocolFee)
+        // pack starting from the "lowest" field
+        Slot0 _slot0 = Slot0.wrap(bytes32(0))
+            .setSqrtPriceX96(sqrtPriceX96)
+            .setTick(tick)
+            .setProtocolFee(protocolFee)
             .setLpFee(lpFee);
 
+        // verify each field was correctly packed and can be unpacked
         assertEq(_slot0.sqrtPriceX96(), sqrtPriceX96);
         assertEq(_slot0.tick(), tick);
         assertEq(_slot0.protocolFee(), protocolFee);
         assertEq(_slot0.lpFee(), lpFee);
 
-        // pack starting from "highest" field
-        _slot0 = Slot0.wrap(bytes32(0)).setLpFee(lpFee).setProtocolFee(protocolFee).setTick(tick).setSqrtPriceX96(
-            sqrtPriceX96
-        );
+        // pack starting from the "highest" field
+        _slot0 = Slot0.wrap(bytes32(0))
+            .setLpFee(lpFee)
+            .setProtocolFee(protocolFee)
+            .setTick(tick)
+            .setSqrtPriceX96(sqrtPriceX96);
 
+        // verify each field was correctly packed and can be unpacked
         assertEq(_slot0.sqrtPriceX96(), sqrtPriceX96);
         assertEq(_slot0.tick(), tick);
         assertEq(_slot0.protocolFee(), protocolFee);


### PR DESCRIPTION
In response to Issue #797, the bit masks are now inlined as opposed to being defined as constants.

Slot0.t.sol previously deviated from the standard of inline bit masks, by instead defining them as constants. I've updated the code so that they now conform to the standard that the other contracts adhere to, which is masks being defined inline.

Please feel free to respond to the pull request or reach out via my socials if there are any changes that need to be made.