### PR TITLE
Define and Implement Dynamic Fee Update Event

### DIFF
--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -342,6 +342,9 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
         newDynamicLPFee.validate();
         PoolId id = key.toId();
         _pools[id].setLPFee(newDynamicLPFee);
+
+        // Emit the DynamicLPFeeUpdated event
+        emit DynamicLPFeeUpdated(key, newDynamicLPFee, msg.sender);
     }
 
     // if settling native, integrators should still call `sync` first to avoid DoS attack vectors

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -227,6 +227,12 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
     /// If the upper 12 bytes are not 0, they will be 0-ed out
     function burn(address from, uint256 id, uint256 amount) external;
 
+    /// @notice Emitted when a dynamic LP fee is updated
+    /// @param poolKey The pool key for the pool whose LP fee was updated
+    /// @param newDynamicLPFee The new dynamic LP fee value
+    /// @param updater The address that initiated the update
+    event DynamicLPFeeUpdated(PoolKey indexed poolKey, uint24 newDynamicLPFee, address indexed updater);
+
     /// @notice Updates the pools lp fees for the a pool that has enabled dynamic lp fees.
     /// @dev A swap fee totaling MAX_SWAP_FEE (100%) makes exact output swaps impossible since the input is entirely consumed by the fee
     /// @param key The key of the pool to update dynamic LP fees for

--- a/src/test/ProxyPoolManager.sol
+++ b/src/test/ProxyPoolManager.sol
@@ -189,6 +189,9 @@ contract ProxyPoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909
         newDynamicLPFee.validate();
         PoolId id = key.toId();
         _pools[id].setLPFee(newDynamicLPFee);
+
+        // Emit the DynamicLPFeeUpdated event
+        emit DynamicLPFeeUpdated(key, newDynamicLPFee, msg.sender);
     }
 
     /// @notice Make a delegate call, bubble up any error or return the result


### PR DESCRIPTION
## Related Issue

#920 

## Description of changes

This PR declares a new event `DynamicLPFeeUpdated` within the `IPoolManager` contract (found in `IPoolManager.sol`) which is essentially an interface contract to be inherited by the `PoolManager` contract (found in `PoolManager.sol`). The new event is emitted whenever the function `updateDynamicLPFee` in is called, and is called on the last line of the function definition to ensure it is only called in the case that the function has executed properly.

In using 

`grep -rl "is IPoolManager" --include="*.sol" .`

We can see that the only two contracts in the `v4-core` repo which inherit from `IPoolManager` are in `./src/test/ProxyPoolManager.sol` and `./src/test/ProxyPoolManager.sol`.  I’ve implemented the event emissions appropriately in both cases.
