### PR TITLE
test: m02 and liquidity

### DIFF
--- a/test/ModifyLiquidity.t.sol
+++ b/test/ModifyLiquidity.t.sol
@@ -19,6 +19,8 @@ import {Fuzzers} from "../src/test/Fuzzers.sol";
 import {TickMath} from "src/libraries/TickMath.sol";
 import {toBalanceDelta} from "src/types/BalanceDelta.sol";
 import {Logger} from "./utils/Logger.sol";
+import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
+import "forge-std/console2.sol";
 
 contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers {
     using StateLibrary for IPoolManager;
@@ -311,5 +313,119 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
         modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
         vm.snapshotGasLastCall("add liquidity to already existing position with salt");
+    }
+
+    /// @dev verify that liquidity positions are not impacted by m02
+    /// i.e. slot0.tick = -61 and slot0.sqrtPriceX96 = sqrtPriceAtTick(-60)
+    /// a user cannot adjust slot0.sqrtPriceX96 to withdraw 2 tokens on the range [-120, -60]
+    /// because a small trade will realign the tick to -60
+    function test_modifyLiquidity_m02_tickUpper() public {
+        assertEq(simpleKey.tickSpacing, 60);
+        LIQ_PARAM_SALT.liquidityDelta = 10_000e18; // add a lot of liquidity
+
+        // Add to range [-120, 120]
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // Add to range [-120, -60]
+        uint256 balance0Before = currency0.balanceOfSelf();
+        uint256 balance1Before = currency1.balanceOfSelf();
+        LIQ_PARAM_SALT.tickLower = -120;
+        LIQ_PARAM_SALT.tickUpper = -60;
+        LIQ_PARAM_SALT.liquidityDelta = 1e18;
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // paid token1
+        assertGt(balance1Before, currency1.balanceOfSelf());
+        // did not pay token0
+        assertEq(balance0Before, currency0.balanceOfSelf());
+
+        // push the price to tick = -60
+        IPoolManager.SwapParams memory swapParams = IPoolManager.SwapParams({
+            zeroForOne: true,
+            amountSpecified: -1000e18,
+            sqrtPriceLimitX96: TickMath.getSqrtPriceAtTick(-60)
+        });
+        PoolSwapTest.TestSettings memory testSettings =
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
+        swapRouter.swap(simpleKey, swapParams, testSettings, ZERO_BYTES);
+
+        // validate m02: tick and sqrtPriceX96 disagree
+        (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(simplePoolId);
+        assertEq(tick, -61);
+        assertEq(sqrtPriceX96, TickMath.getSqrtPriceAtTick(-60));
+        assertEq(TickMath.getTickAtSqrtPrice(sqrtPriceX96), -60);
+
+        // push the price just slightly
+        swapParams.zeroForOne = false;
+        swapParams.amountSpecified = -1;
+        swapParams.sqrtPriceLimitX96 = MAX_PRICE_LIMIT;
+        swapRouter.swap(simpleKey, swapParams, testSettings, ZERO_BYTES);
+
+        // even with a 1 wei trade, the tick realigns
+        (sqrtPriceX96, tick,,) = manager.getSlot0(simplePoolId);
+        assertEq(tick, -60);
+        assertEq(TickMath.getTickAtSqrtPrice(sqrtPriceX96), -60);
+
+        // withdraw liquidity and receive token1 only
+        balance0Before = currency0.balanceOfSelf();
+        balance1Before = currency1.balanceOfSelf();
+        LIQ_PARAM_SALT.liquidityDelta = -1e18;
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // receive token1
+        assertGt(currency1.balanceOfSelf(), balance1Before);
+        // did not receive token0
+        assertEq(balance0Before, currency0.balanceOfSelf());
+    }
+
+    /// @dev verify that liquidity positions are not impacted by m02
+    /// i.e. slot0.tick = -61 and slot0.sqrtPriceX96 = sqrtPriceAtTick(-60)
+    /// when withdrawing liquidity on the range [-120, -60], it is not possible to withdraw 2 tokens
+    function test_modifyLiquidity_m02_tickUpper_2() public {
+        assertEq(simpleKey.tickSpacing, 60);
+        LIQ_PARAM_SALT.liquidityDelta = 10_000e18;
+
+        // Add to range [-120, 120]
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // Add to range [-120, -60]
+        uint256 balance0Before = currency0.balanceOfSelf();
+        uint256 balance1Before = currency1.balanceOfSelf();
+        LIQ_PARAM_SALT.tickLower = -120;
+        LIQ_PARAM_SALT.tickUpper = -60;
+        LIQ_PARAM_SALT.liquidityDelta = 1e18;
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // paid token1
+        assertGt(balance1Before, currency1.balanceOfSelf());
+        // did not pay token0
+        assertEq(balance0Before, currency0.balanceOfSelf());
+
+        // push the price to tick = -60
+        IPoolManager.SwapParams memory swapParams = IPoolManager.SwapParams({
+            zeroForOne: true,
+            amountSpecified: -200e18,
+            sqrtPriceLimitX96: TickMath.getSqrtPriceAtTick(-60)
+        });
+        PoolSwapTest.TestSettings memory testSettings =
+            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
+        swapRouter.swap(simpleKey, swapParams, testSettings, ZERO_BYTES);
+
+        // validate m02: tick and sqrtPriceX96 disagree
+        (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(simplePoolId);
+        assertEq(tick, -61);
+        assertEq(sqrtPriceX96, TickMath.getSqrtPriceAtTick(-60));
+        assertEq(TickMath.getTickAtSqrtPrice(sqrtPriceX96), -60);
+
+        // withdraw liquidity and receive token1 only
+        balance0Before = currency0.balanceOfSelf();
+        balance1Before = currency1.balanceOfSelf();
+        LIQ_PARAM_SALT.liquidityDelta = -1e18;
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // receive token1
+        assertGt(currency1.balanceOfSelf(), balance1Before);
+        // did not receive token0
+        assertEq(balance0Before, currency0.balanceOfSelf());
     }
 }

--- a/test/ModifyLiquidity.t.sol
+++ b/test/ModifyLiquidity.t.sol
@@ -20,6 +20,7 @@ import {TickMath} from "src/libraries/TickMath.sol";
 import {toBalanceDelta} from "src/types/BalanceDelta.sol";
 import {Logger} from "./utils/Logger.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
+import "forge-std/console2.sol";
 
 contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers {
     using StateLibrary for IPoolManager;
@@ -314,13 +315,13 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         vm.snapshotGasLastCall("add liquidity to already existing position with salt");
     }
 
-    /// @dev verify that liquidity positions are not impacted by m02
+    /// @dev verify that liquidity positions are not impacted by m02, at the upper tick
     /// i.e. slot0.tick = -61 and slot0.sqrtPriceX96 = sqrtPriceAtTick(-60)
     /// a user cannot adjust slot0.sqrtPriceX96 to withdraw 2 tokens on the range [-120, -60]
     /// because a small trade will realign the tick to -60
     function test_modifyLiquidity_m02_tickUpper() public {
-        assertEq(simpleKey.tickSpacing, 60);
-        LIQ_PARAM_SALT.liquidityDelta = 10_000e18; // add a lot of liquidity
+        // fee-less pool to ensure liquidity withdrawals are not impacted by fees
+        (simpleKey, simplePoolId) = initPool(currency0, currency1, IHooks(address(0)), 0, 60, SQRT_PRICE_1_1);
 
         // Add to range [-120, 120]
         modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
@@ -341,12 +342,10 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         // push the price to tick = -60
         IPoolManager.SwapParams memory swapParams = IPoolManager.SwapParams({
             zeroForOne: true,
-            amountSpecified: -1000e18,
+            amountSpecified: -10_000e18,
             sqrtPriceLimitX96: TickMath.getSqrtPriceAtTick(-60)
         });
-        PoolSwapTest.TestSettings memory testSettings =
-            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        swapRouter.swap(simpleKey, swapParams, testSettings, ZERO_BYTES);
+        swapRouter.swap(simpleKey, swapParams, SWAP_SETTINGS, ZERO_BYTES);
 
         // validate m02: tick and sqrtPriceX96 disagree
         (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(simplePoolId);
@@ -356,9 +355,9 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
 
         // push the price just slightly
         swapParams.zeroForOne = false;
-        swapParams.amountSpecified = -1;
+        swapParams.amountSpecified = -1 wei;
         swapParams.sqrtPriceLimitX96 = MAX_PRICE_LIMIT;
-        swapRouter.swap(simpleKey, swapParams, testSettings, ZERO_BYTES);
+        swapRouter.swap(simpleKey, swapParams, SWAP_SETTINGS, ZERO_BYTES);
 
         // even with a 1 wei trade, the tick realigns
         (sqrtPriceX96, tick,,) = manager.getSlot0(simplePoolId);
@@ -377,12 +376,12 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         assertEq(balance0Before, currency0.balanceOfSelf());
     }
 
-    /// @dev verify that liquidity positions are not impacted by m02
+    /// @dev verify that liquidity positions are not impacted by m02, at the upper tick
     /// i.e. slot0.tick = -61 and slot0.sqrtPriceX96 = sqrtPriceAtTick(-60)
     /// when withdrawing liquidity on the range [-120, -60], it is not possible to withdraw 2 tokens
-    function test_modifyLiquidity_m02_tickUpper_2() public {
-        assertEq(simpleKey.tickSpacing, 60);
-        LIQ_PARAM_SALT.liquidityDelta = 10_000e18;
+    function test_modifyLiquidity_m02_tickUpper_withoutSwap() public {
+        // fee-less pool to ensure liquidity withdrawals are not impacted by fees
+        (simpleKey, simplePoolId) = initPool(currency0, currency1, IHooks(address(0)), 0, 60, SQRT_PRICE_1_1);
 
         // Add to range [-120, 120]
         modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
@@ -406,9 +405,7 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
             amountSpecified: -200e18,
             sqrtPriceLimitX96: TickMath.getSqrtPriceAtTick(-60)
         });
-        PoolSwapTest.TestSettings memory testSettings =
-            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        swapRouter.swap(simpleKey, swapParams, testSettings, ZERO_BYTES);
+        swapRouter.swap(simpleKey, swapParams, SWAP_SETTINGS, ZERO_BYTES);
 
         // validate m02: tick and sqrtPriceX96 disagree
         (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(simplePoolId);
@@ -426,5 +423,62 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         assertGt(currency1.balanceOfSelf(), balance1Before);
         // did not receive token0
         assertEq(balance0Before, currency0.balanceOfSelf());
+    }
+
+    /// @dev verify that liquidity positions are not impacted by m02 on tickLower
+    /// LP range [60, 120], tick = 59, sqrtPriceX96 = sqrtPriceAtTick(60)
+    function test_modifyLiquidity_m02_tickLower() public {
+        // fee-less pool to ensure liquidity withdrawals are not impacted by fees
+        (simpleKey, simplePoolId) = initPool(currency0, currency1, IHooks(address(0)), 0, 60, SQRT_PRICE_1_1);
+
+        // Add to range [-120, 120]
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // Add to range [60, 120]
+        uint256 balance0Before = currency0.balanceOfSelf();
+        uint256 balance1Before = currency1.balanceOfSelf();
+        LIQ_PARAM_SALT.tickLower = 60;
+        LIQ_PARAM_SALT.tickUpper = 120;
+        LIQ_PARAM_SALT.liquidityDelta = 1e18;
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // paid token0
+        assertGt(balance0Before, currency0.balanceOfSelf());
+        // did not pay token1
+        assertEq(balance1Before, currency1.balanceOfSelf());
+
+        // push the price to tick = 61
+        IPoolManager.SwapParams memory swapParams = IPoolManager.SwapParams({
+            zeroForOne: false,
+            amountSpecified: -20000e18,
+            sqrtPriceLimitX96: TickMath.getSqrtPriceAtTick(61)
+        });
+        swapRouter.swap(simpleKey, swapParams, SWAP_SETTINGS, ZERO_BYTES);
+        (uint160 sqrtPriceX96, int24 tick,,) = manager.getSlot0(simplePoolId);
+        assertEq(tick, 61);
+        assertEq(sqrtPriceX96, TickMath.getSqrtPriceAtTick(61));
+        assertEq(TickMath.getTickAtSqrtPrice(sqrtPriceX96), 61);
+
+        // push the price to tick = 60, but tick is set to 59 because of m02 behavior
+        swapParams.zeroForOne = true;
+        swapParams.sqrtPriceLimitX96 = TickMath.getSqrtPriceAtTick(60);
+        swapRouter.swap(simpleKey, swapParams, SWAP_SETTINGS, ZERO_BYTES);
+
+        // validate m02: tick and sqrtPriceX96 disagree
+        (sqrtPriceX96, tick,,) = manager.getSlot0(simplePoolId);
+        assertEq(tick, 59);
+        assertEq(sqrtPriceX96, TickMath.getSqrtPriceAtTick(60));
+        assertEq(TickMath.getTickAtSqrtPrice(sqrtPriceX96), 60);
+
+        // withdraw liquidity and receive token0 only
+        balance0Before = currency0.balanceOfSelf();
+        balance1Before = currency1.balanceOfSelf();
+        LIQ_PARAM_SALT.liquidityDelta = -1e18;
+        modifyLiquidityRouter.modifyLiquidity(simpleKey, LIQ_PARAM_SALT, ZERO_BYTES);
+
+        // receive token0
+        assertGt(currency0.balanceOfSelf(), balance0Before);
+        // did not receive token1
+        assertEq(balance1Before, currency1.balanceOfSelf());
     }
 }

--- a/test/ModifyLiquidity.t.sol
+++ b/test/ModifyLiquidity.t.sol
@@ -19,7 +19,6 @@ import {Fuzzers} from "../src/test/Fuzzers.sol";
 import {TickMath} from "src/libraries/TickMath.sol";
 import {toBalanceDelta} from "src/types/BalanceDelta.sol";
 import {Logger} from "./utils/Logger.sol";
-import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 
 contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers {
     using StateLibrary for IPoolManager;

--- a/test/ModifyLiquidity.t.sol
+++ b/test/ModifyLiquidity.t.sol
@@ -20,7 +20,6 @@ import {TickMath} from "src/libraries/TickMath.sol";
 import {toBalanceDelta} from "src/types/BalanceDelta.sol";
 import {Logger} from "./utils/Logger.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
-import "forge-std/console2.sol";
 
 contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers {
     using StateLibrary for IPoolManager;

--- a/test/PoolManager.t.sol
+++ b/test/PoolManager.t.sol
@@ -1205,7 +1205,7 @@ contract PoolManagerTest is Test, Deployers {
         (, int24 currentTick,,) = manager.getSlot0(poolId);
         assertEq(key.tickSpacing, 60);
         assertEq(currentTick, 0);
-        
+
         // Add full range liquidity
         LIQUIDITY_PARAMS.tickLower = TickMath.minUsableTick(key.tickSpacing);
         LIQUIDITY_PARAMS.tickUpper = TickMath.maxUsableTick(key.tickSpacing);
@@ -1227,7 +1227,7 @@ contract PoolManagerTest is Test, Deployers {
         // fuzz target tick 180 +/- 128
         int24 targetTick = zeroForOne ? -int24(180) : int24(180);
         targetTick += int24(tickOffset);
-        
+
         uint160 targetSqrtPrice = TickMath.getSqrtPriceAtTick(targetTick);
         IPoolManager.SwapParams memory swapParams = IPoolManager.SwapParams({
             zeroForOne: zeroForOne,

--- a/test/utils/Deployers.sol
+++ b/test/utils/Deployers.sol
@@ -48,6 +48,8 @@ contract Deployers is Test {
         IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
     IPoolManager.SwapParams public SWAP_PARAMS =
         IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+    PoolSwapTest.TestSettings public SWAP_SETTINGS =
+        PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
     // Global variables
     Currency internal currency0;
@@ -227,7 +229,7 @@ contract Deployers is Test {
                 amountSpecified: amountSpecified,
                 sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT
             }),
-            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
+            SWAP_SETTINGS,
             hookData
         );
     }
@@ -272,7 +274,7 @@ contract Deployers is Test {
                 amountSpecified: amountSpecified,
                 sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT
             }),
-            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false}),
+            SWAP_SETTINGS,
             hookData
         );
     }


### PR DESCRIPTION
## Related Issue

Verify that M02 (slot0.tick and slot0.sqrtPriceX96 disagreement) does not impact liquidity removal

![image](https://github.com/user-attachments/assets/ecda8455-a2d1-4d8b-9e75-f32b4e6bbe2e)

In the image above, it is impossible to achieve a state where tick is misaligned and sqrtPriceX96 is NOT on an LP boundary

i.e. 
* slot0.tick = -61
* LP Range: [-120, -60]
* slot0.sqrtPriceX96 > getSqrtPriceAtTick(-60)