### PR TITLE
Add npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-# if you add a file here, add it to `.npmignore` too
 artifacts/
 cache/
 crytic-export/
@@ -6,4 +5,3 @@ node_modules/
 typechain/
 foundry-out/
 .vscode/
-out/


### PR DESCRIPTION
Allows us to publish the `out` folder to npm so build artifacts are available