### PR TITLE
Fix amount0 and amount1 calculation with improved price range checks

### DIFF
--- a/test/utils/AmountHelpers.sol
+++ b/test/utils/AmountHelpers.sol
@@ -18,12 +18,23 @@ library AmountHelpers {
     ) public view returns (uint256 amount0, uint256 amount1) {
         PoolId id = key.toId();
         uint128 liquidity = StateLibrary.getLiquidity(manager, id);
-        (uint160 sqrtPriceX96,,,) = StateLibrary.getSlot0(manager, id);
+        (uint160 sqrtPriceX96, , , ) = StateLibrary.getSlot0(manager, id);
 
         uint160 sqrtPriceX96Lower = TickMath.getSqrtPriceAtTick(params.tickLower);
         uint160 sqrtPriceX96Upper = TickMath.getSqrtPriceAtTick(params.tickUpper);
 
-        amount0 = LiquidityAmounts.getAmount0ForLiquidity(sqrtPriceX96Lower, sqrtPriceX96, liquidity);
-        amount1 = LiquidityAmounts.getAmount1ForLiquidity(sqrtPriceX96Upper, sqrtPriceX96, liquidity);
+        require(sqrtPriceX96 >= sqrtPriceX96Lower && sqrtPriceX96 <= sqrtPriceX96Upper, "Price out of range");
+
+        if (sqrtPriceX96 < sqrtPriceX96Lower) {
+            amount0 = LiquidityAmounts.getAmount0ForLiquidity(sqrtPriceX96, sqrtPriceX96Lower, liquidity);
+        } else {
+            amount0 = LiquidityAmounts.getAmount0ForLiquidity(sqrtPriceX96Lower, sqrtPriceX96, liquidity);
+        }
+
+        if (sqrtPriceX96 > sqrtPriceX96Upper) {
+            amount1 = LiquidityAmounts.getAmount1ForLiquidity(sqrtPriceX96Upper, sqrtPriceX96, liquidity);
+        } else {
+            amount1 = LiquidityAmounts.getAmount1ForLiquidity(sqrtPriceX96, sqrtPriceX96Upper, liquidity);
+        }
     }
 }


### PR DESCRIPTION
## Related Issue

#954 

## Description of changes
1. Fixed Calculation Logic in getMaxAmountInForPool:
- Ensured correct order of sqrtPriceX96 values by adding conditional checks.
- Added validation to verify that the current price is within the tick range.
- Improved handling of edge cases such as price being exactly at boundaries.
2. Enhanced Error Handling:
- Added require statements to check if the price is within the acceptable range.
- Proper error messages for out-of-range prices.
