### PR TITLE
fix: StateLibrary change @param

### DIFF
--- a/src/libraries/StateLibrary.sol
+++ b/src/libraries/StateLibrary.sol
@@ -219,7 +219,7 @@ library StateLibrary {
      * @notice Retrieves the position information of a pool without needing to calculate the `positionId`.
      * @dev Corresponds to pools[poolId].positions[positionId]
      * @param poolId The ID of the pool.
-     * @param owner The owner of the liquidity position.
+     * @param posm The position manager.
      * @param tickLower The lower tick of the liquidity range.
      * @param tickUpper The upper tick of the liquidity range.
      * @param salt The bytes32 randomness to further distinguish position state.
@@ -230,13 +230,13 @@ library StateLibrary {
     function getPositionInfo(
         IPoolManager manager,
         PoolId poolId,
-        address owner,
+        address posm,
         int24 tickLower,
         int24 tickUpper,
         bytes32 salt
     ) internal view returns (uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128) {
-        // positionKey = keccak256(abi.encodePacked(owner, tickLower, tickUpper, salt))
-        bytes32 positionKey = Position.calculatePositionKey(owner, tickLower, tickUpper, salt);
+        // positionKey = keccak256(abi.encodePacked(posm, tickLower, tickUpper, salt))
+        bytes32 positionKey = Position.calculatePositionKey(posm, tickLower, tickUpper, salt);
 
         (liquidity, feeGrowthInside0LastX128, feeGrowthInside1LastX128) = getPositionInfo(manager, poolId, positionKey);
     }


### PR DESCRIPTION
## Related Issue
Trying to get position liquidity like in guide https://docs.uniswap.org/contracts/v4/guides/read-pool-state#getpositioninfo
Function getPositionInfo(
        IPoolManager manager,
        PoolId poolId,
        address owner,
        int24 tickLower,
        int24 tickUpper,
        bytes32 salt
    ) doesn't work with @param owner The owner of the liquidity position.
Works with @param address of the position manager.

In v4-periphery -> PositionManager.sol  -> 
bytes32 positionId = Position.calculatePositionKey(address(this), tickLower, tickUpper, bytes32(tokenId));
The same calculatePositionKey with address(this) == address(positionManager)

## Description of changes
Changed in StateLibrary.sol function getPositionInfo @param owner The owner of the liquidity position. to @param posm The position manager.
