### PR TITLE
docs: corrects uint258 by uint256 in the function documentation

### DIFF
--- a/test/utils/LiquidityAmounts.sol
+++ b/test/utils/LiquidityAmounts.sol
@@ -8,7 +8,7 @@ import "../../src/libraries/FixedPoint96.sol";
 /// @notice Provides functions for computing liquidity amounts from token amounts and prices
 library LiquidityAmounts {
     /// @notice Downcasts uint256 to uint128
-    /// @param x The uint258 to be downcasted
+    /// @param x The uint256 to be downcasted
     /// @return y The passed value, downcasted to uint128
     function toUint128(uint256 x) private pure returns (uint128 y) {
         require((y = uint128(x)) == x, "liquidity overflow");


### PR DESCRIPTION
## Related Issue

No related issue; documentation fix.


## Description of changes

Corrects a typographical error in the function documentation within the `LiquidityAmounts` library by replacing the incorrect parameter type `uint258` with the correct type `uint256` for the function `toUint128`. This correction ensures clarity and accuracy in the documentation.