### PR TITLE
Safer readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,14 @@ contract MyContract is IUnlockCallback {
     }
 
     function unlockCallback(bytes calldata data) external returns (bytes memory) {
+        // disallow arbitrary caller
+        if (msg.sender != address(poolManager) revert Unauthorized();
         // perform pool actions
         poolManager.swap(...)
     }
 }
 
+error Unauthorized();
 ```
 
 ## License


### PR DESCRIPTION
## Related Issue

N/A

## Description of changes

Ensuring that `unlockCallback` is only called by the `poolManager` is almost always a critically important security feature, so imo it should be included even in the most basic of examples