### PR TITLE
Fix tests for Foundry Stable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Lint
         run: forge fmt --check
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Configure npm caching
         with:
           path: ~/.npm

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ solc = "0.8.26"
 evm_version = "cancun"
 gas_limit = "300000000"
 bytecode_hash = "none"
+allow_internal_expect_revert = true
 
 [profile.default.fuzz]
 runs = 1000

--- a/test/ERC6909Claims.t.sol
+++ b/test/ERC6909Claims.t.sol
@@ -370,7 +370,9 @@ contract ERC6909ClaimsTest is Test {
         token.transferFrom(sender, receiver, id, amount);
     }
 
-    function test_revertTransferFromBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount) public {
+    function test_revertTransferFromBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount)
+        public
+    {
         amount = bound(amount, 1, type(uint256).max);
         uint256 overflowAmount = type(uint256).max - amount + 1;
 
@@ -386,7 +388,9 @@ contract ERC6909ClaimsTest is Test {
         token.transferFrom(sender, receiver, id, overflowAmount);
     }
 
-    function test_revertTransferFromNotAuthorized(address sender, address receiver, uint256 id, uint256 amount) public {
+    function test_revertTransferFromNotAuthorized(address sender, address receiver, uint256 id, uint256 amount)
+        public
+    {
         amount = bound(amount, 1, type(uint256).max);
 
         token.mint(sender, id, amount);

--- a/test/ERC6909Claims.t.sol
+++ b/test/ERC6909Claims.t.sol
@@ -345,7 +345,7 @@ contract ERC6909ClaimsTest is Test {
     }
 
     function test_revertTransferBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount) public {
-        vm.assume(sender != receiver);
+        if (sender == receiver) return;
         amount = bound(amount, 1, type(uint256).max);
         uint256 overflowAmount = type(uint256).max - amount + 1;
 
@@ -374,7 +374,7 @@ contract ERC6909ClaimsTest is Test {
     function test_revertTransferFromBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount)
         public
     {
-        vm.assume(sender != receiver);
+        if (sender == receiver) return;
         amount = bound(amount, 1, type(uint256).max);
         uint256 overflowAmount = type(uint256).max - amount + 1;
 

--- a/test/ERC6909Claims.t.sol
+++ b/test/ERC6909Claims.t.sol
@@ -345,6 +345,7 @@ contract ERC6909ClaimsTest is Test {
     }
 
     function test_revertTransferBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount) public {
+        vm.assume(sender != receiver);
         amount = bound(amount, 1, type(uint256).max);
         uint256 overflowAmount = type(uint256).max - amount + 1;
 
@@ -373,6 +374,7 @@ contract ERC6909ClaimsTest is Test {
     function test_revertTransferFromBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount)
         public
     {
+        vm.assume(sender != receiver);
         amount = bound(amount, 1, type(uint256).max);
         uint256 overflowAmount = type(uint256).max - amount + 1;
 

--- a/test/ERC6909Claims.t.sol
+++ b/test/ERC6909Claims.t.sol
@@ -142,43 +142,22 @@ contract ERC6909ClaimsTest is Test {
         assertEq(token.balanceOf(receiver, 1337), 70);
     }
 
-    function testFailMintBalanceOverflow() public {
+    function test_revertMintBalanceOverflow() public {
         token.mint(address(0xDEAD), 1337, type(uint256).max);
+        vm.expectRevert();
         token.mint(address(0xDEAD), 1337, 1);
     }
 
-    function testFailTransferBalanceUnderflow() public {
+    function test_revertTransferBalanceUnderflow() public {
         address sender = address(0xABCD);
         address receiver = address(0xBEEF);
 
+        vm.expectRevert();
         vm.prank(sender);
         token.transferFrom(sender, receiver, 1337, 1);
     }
 
-    function testFailTransferBalanceOverflow() public {
-        address sender = address(0xABCD);
-        address receiver = address(0xBEEF);
-
-        token.mint(sender, 1337, type(uint256).max);
-
-        vm.prank(sender);
-        token.transferFrom(sender, receiver, 1337, type(uint256).max);
-
-        token.mint(sender, 1337, 1);
-
-        vm.prank(sender);
-        token.transferFrom(sender, receiver, 1337, 1);
-    }
-
-    function testFailTransferFromBalanceUnderflow() public {
-        address sender = address(0xABCD);
-        address receiver = address(0xBEEF);
-
-        vm.prank(sender);
-        token.transferFrom(sender, receiver, 1337, 1);
-    }
-
-    function testFailTransferFromBalanceOverflow() public {
+    function test_revertTransferBalanceOverflow() public {
         address sender = address(0xABCD);
         address receiver = address(0xBEEF);
 
@@ -189,16 +168,43 @@ contract ERC6909ClaimsTest is Test {
 
         token.mint(sender, 1337, 1);
 
+        vm.expectRevert();
         vm.prank(sender);
         token.transferFrom(sender, receiver, 1337, 1);
     }
 
-    function testFailTransferFromNotAuthorized() public {
+    function test_revertTransferFromBalanceUnderflow() public {
+        address sender = address(0xABCD);
+        address receiver = address(0xBEEF);
+
+        vm.expectRevert();
+        vm.prank(sender);
+        token.transferFrom(sender, receiver, 1337, 1);
+    }
+
+    function test_revertTransferFromBalanceOverflow() public {
+        address sender = address(0xABCD);
+        address receiver = address(0xBEEF);
+
+        token.mint(sender, 1337, type(uint256).max);
+
+        vm.prank(sender);
+        token.transferFrom(sender, receiver, 1337, type(uint256).max);
+
+        token.mint(sender, 1337, 1);
+
+        vm.expectRevert();
+        vm.prank(sender);
+        token.transferFrom(sender, receiver, 1337, 1);
+    }
+
+    function test_revertTransferFromNotAuthorized() public {
         address sender = address(0xABCD);
         address receiver = address(0xBEEF);
 
         token.mint(sender, 1337, 100);
 
+        vm.expectRevert();
         token.transferFrom(sender, receiver, 1337, 100);
     }
 
@@ -330,14 +336,15 @@ contract ERC6909ClaimsTest is Test {
         }
     }
 
-    function testFailTransferBalanceUnderflow(address sender, address receiver, uint256 id, uint256 amount) public {
+    function test_revertTransferBalanceUnderflow(address sender, address receiver, uint256 id, uint256 amount) public {
         amount = bound(amount, 1, type(uint256).max);
 
+        vm.expectRevert();
         vm.prank(sender);
         token.transfer(receiver, id, amount);
     }
 
-    function testFailTransferBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount) public {
+    function test_revertTransferBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount) public {
         amount = bound(amount, 1, type(uint256).max);
         uint256 overflowAmount = type(uint256).max - amount + 1;
 
@@ -348,20 +355,22 @@ contract ERC6909ClaimsTest is Test {
 
         token.mint(sender, id, overflowAmount);
 
+        vm.expectRevert();
         vm.prank(sender);
         token.transfer(receiver, id, overflowAmount);
     }
 
-    function testFailTransferFromBalanceUnderflow(address sender, address receiver, uint256 id, uint256 amount)
+    function test_revertTransferFromBalanceUnderflow(address sender, address receiver, uint256 id, uint256 amount)
         public
     {
         amount = bound(amount, 1, type(uint256).max);
 
+        vm.expectRevert();
         vm.prank(sender);
         token.transferFrom(sender, receiver, id, amount);
     }
 
-    function testFailTransferFromBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount) public {
+    function test_revertTransferFromBalanceOverflow(address sender, address receiver, uint256 id, uint256 amount) public {
         amount = bound(amount, 1, type(uint256).max);
         uint256 overflowAmount = type(uint256).max - amount + 1;
 
@@ -372,16 +381,18 @@ contract ERC6909ClaimsTest is Test {
 
         token.mint(sender, id, overflowAmount);
 
+        vm.expectRevert();
         vm.prank(sender);
         token.transferFrom(sender, receiver, id, overflowAmount);
     }
 
-    function testFailTransferFromNotAuthorized(address sender, address receiver, uint256 id, uint256 amount) public {
+    function test_revertTransferFromNotAuthorized(address sender, address receiver, uint256 id, uint256 amount) public {
         amount = bound(amount, 1, type(uint256).max);
 
         token.mint(sender, id, amount);
 
         vm.assume(sender != address(this));
+        vm.expectRevert();
         token.transferFrom(sender, receiver, id, amount);
     }
 }


### PR DESCRIPTION
## Related Issue

CI busted because foundry stable has breaking changes related to tests

## Description of changes

* Added `allow_internal_expect_revert = true` to the toml ([migration guide](https://book.getfoundry.sh/guides/v1.0-migration#expect-revert-cheatcode-disabled-on-internal-calls-by-default))

* Moved `testFail*` functions to `test_revert*` + vm.expectRevert ([migration guide](https://book.getfoundry.sh/guides/v1.0-migration#removed-support-for-testfail-tests))

* also `actions/cache@v2` in the lint CI was deprecated so bumped that version