### PR TITLE
fix(deps): resolve circular dependency that breaks clean builds

### DIFF
--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -16,6 +16,7 @@ import {IUnlockCallback} from "./interfaces/callback/IUnlockCallback.sol";
 import {ProtocolFees} from "./ProtocolFees.sol";
 import {ERC6909Claims} from "./ERC6909Claims.sol";
 import {PoolId} from "./types/PoolId.sol";
+import {PoolOperation} from "./types/PoolOperation.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "./types/BalanceDelta.sol";
 import {BeforeSwapDelta} from "./types/BeforeSwapDelta.sol";
 import {Lock} from "./libraries/Lock.sol";
@@ -143,7 +144,7 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     /// @inheritdoc IPoolManager
     function modifyLiquidity(
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes calldata hookData
     ) external onlyWhenUnlocked noDelegateCall returns (BalanceDelta callerDelta, BalanceDelta feesAccrued) {
         PoolId id = key.toId();
@@ -182,7 +183,7 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
-    function swap(PoolKey memory key, IPoolManager.SwapParams memory params, bytes calldata hookData)
+    function swap(PoolKey memory key, PoolOperation.SwapParams memory params, bytes calldata hookData)
         external
         onlyWhenUnlocked
         noDelegateCall

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -16,7 +16,7 @@ import {IUnlockCallback} from "./interfaces/callback/IUnlockCallback.sol";
 import {ProtocolFees} from "./ProtocolFees.sol";
 import {ERC6909Claims} from "./ERC6909Claims.sol";
 import {PoolId} from "./types/PoolId.sol";
-import {PoolOperation} from "./types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "./types/PoolOperation.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "./types/BalanceDelta.sol";
 import {BeforeSwapDelta} from "./types/BeforeSwapDelta.sol";
 import {Lock} from "./libraries/Lock.sol";
@@ -142,11 +142,12 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
-    function modifyLiquidity(
-        PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
-        bytes calldata hookData
-    ) external onlyWhenUnlocked noDelegateCall returns (BalanceDelta callerDelta, BalanceDelta feesAccrued) {
+    function modifyLiquidity(PoolKey memory key, ModifyLiquidityParams memory params, bytes calldata hookData)
+        external
+        onlyWhenUnlocked
+        noDelegateCall
+        returns (BalanceDelta callerDelta, BalanceDelta feesAccrued)
+    {
         PoolId id = key.toId();
         {
             Pool.State storage pool = _getPool(id);
@@ -183,7 +184,7 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
-    function swap(PoolKey memory key, PoolOperation.SwapParams memory params, bytes calldata hookData)
+    function swap(PoolKey memory key, SwapParams memory params, bytes calldata hookData)
         external
         onlyWhenUnlocked
         noDelegateCall

--- a/src/interfaces/IHooks.sol
+++ b/src/interfaces/IHooks.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {BeforeSwapDelta} from "../types/BeforeSwapDelta.sol";
 
 /// @notice V4 decides whether to invoke specific hooks by inspecting the least significant bits
@@ -39,7 +39,7 @@ interface IHooks {
     function beforeAddLiquidity(
         address sender,
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata params,
+        ModifyLiquidityParams calldata params,
         bytes calldata hookData
     ) external returns (bytes4);
 
@@ -55,7 +55,7 @@ interface IHooks {
     function afterAddLiquidity(
         address sender,
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata params,
+        ModifyLiquidityParams calldata params,
         BalanceDelta delta,
         BalanceDelta feesAccrued,
         bytes calldata hookData
@@ -70,7 +70,7 @@ interface IHooks {
     function beforeRemoveLiquidity(
         address sender,
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata params,
+        ModifyLiquidityParams calldata params,
         bytes calldata hookData
     ) external returns (bytes4);
 
@@ -86,7 +86,7 @@ interface IHooks {
     function afterRemoveLiquidity(
         address sender,
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata params,
+        ModifyLiquidityParams calldata params,
         BalanceDelta delta,
         BalanceDelta feesAccrued,
         bytes calldata hookData
@@ -100,12 +100,9 @@ interface IHooks {
     /// @return bytes4 The function selector for the hook
     /// @return BeforeSwapDelta The hook's delta in specified and unspecified currencies. Positive: the hook is owed/took currency, negative: the hook owes/sent currency
     /// @return uint24 Optionally override the lp fee, only used if three conditions are met: 1. the Pool has a dynamic fee, 2. the value's 2nd highest bit is set (23rd bit, 0x400000), and 3. the value is less than or equal to the maximum fee (1 million)
-    function beforeSwap(
-        address sender,
-        PoolKey calldata key,
-        PoolOperation.SwapParams calldata params,
-        bytes calldata hookData
-    ) external returns (bytes4, BeforeSwapDelta, uint24);
+    function beforeSwap(address sender, PoolKey calldata key, SwapParams calldata params, bytes calldata hookData)
+        external
+        returns (bytes4, BeforeSwapDelta, uint24);
 
     /// @notice The hook called after a swap
     /// @param sender The initial msg.sender for the swap call
@@ -118,7 +115,7 @@ interface IHooks {
     function afterSwap(
         address sender,
         PoolKey calldata key,
-        PoolOperation.SwapParams calldata params,
+        SwapParams calldata params,
         BalanceDelta delta,
         bytes calldata hookData
     ) external returns (bytes4, int128);

--- a/src/interfaces/IHooks.sol
+++ b/src/interfaces/IHooks.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
-import {IPoolManager} from "./IPoolManager.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {BeforeSwapDelta} from "../types/BeforeSwapDelta.sol";
 
 /// @notice V4 decides whether to invoke specific hooks by inspecting the least significant bits
@@ -39,7 +39,7 @@ interface IHooks {
     function beforeAddLiquidity(
         address sender,
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params,
+        PoolOperation.ModifyLiquidityParams calldata params,
         bytes calldata hookData
     ) external returns (bytes4);
 
@@ -55,7 +55,7 @@ interface IHooks {
     function afterAddLiquidity(
         address sender,
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params,
+        PoolOperation.ModifyLiquidityParams calldata params,
         BalanceDelta delta,
         BalanceDelta feesAccrued,
         bytes calldata hookData
@@ -70,7 +70,7 @@ interface IHooks {
     function beforeRemoveLiquidity(
         address sender,
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params,
+        PoolOperation.ModifyLiquidityParams calldata params,
         bytes calldata hookData
     ) external returns (bytes4);
 
@@ -86,7 +86,7 @@ interface IHooks {
     function afterRemoveLiquidity(
         address sender,
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params,
+        PoolOperation.ModifyLiquidityParams calldata params,
         BalanceDelta delta,
         BalanceDelta feesAccrued,
         bytes calldata hookData
@@ -103,7 +103,7 @@ interface IHooks {
     function beforeSwap(
         address sender,
         PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
+        PoolOperation.SwapParams calldata params,
         bytes calldata hookData
     ) external returns (bytes4, BeforeSwapDelta, uint24);
 
@@ -118,7 +118,7 @@ interface IHooks {
     function afterSwap(
         address sender,
         PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
+        PoolOperation.SwapParams calldata params,
         BalanceDelta delta,
         bytes calldata hookData
     ) external returns (bytes4, int128);

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -10,7 +10,7 @@ import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {PoolId} from "../types/PoolId.sol";
 import {IExtsload} from "./IExtsload.sol";
 import {IExttload} from "./IExttload.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 
 /// @notice Interface for the PoolManager
 interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
@@ -130,7 +130,7 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
     /// @dev Note that feesAccrued can be artificially inflated by a malicious actor and integrators should be careful using the value
     /// For pools with a single liquidity position, actors can donate to themselves to inflate feeGrowthGlobal (and consequently feesAccrued)
     /// atomically donating and collecting fees in the same unlockCallback may make the inflated value more extreme
-    function modifyLiquidity(PoolKey memory key, PoolOperation.ModifyLiquidityParams memory params, bytes calldata hookData)
+    function modifyLiquidity(PoolKey memory key, ModifyLiquidityParams memory params, bytes calldata hookData)
         external
         returns (BalanceDelta callerDelta, BalanceDelta feesAccrued);
 
@@ -142,7 +142,7 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
     /// @dev Swapping on low liquidity pools may cause unexpected swap amounts when liquidity available is less than amountSpecified.
     /// Additionally note that if interacting with hooks that have the BEFORE_SWAP_RETURNS_DELTA_FLAG or AFTER_SWAP_RETURNS_DELTA_FLAG
     /// the hook may alter the swap input/output. Integrators should perform checks on the returned swapDelta.
-    function swap(PoolKey memory key, PoolOperation.SwapParams memory params, bytes calldata hookData)
+    function swap(PoolKey memory key, SwapParams memory params, bytes calldata hookData)
         external
         returns (BalanceDelta swapDelta);
 

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -10,6 +10,7 @@ import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {PoolId} from "../types/PoolId.sol";
 import {IExtsload} from "./IExtsload.sol";
 import {IExttload} from "./IExttload.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 
 /// @notice Interface for the PoolManager
 interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
@@ -119,16 +120,6 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
     /// @return tick The initial tick of the pool
     function initialize(PoolKey memory key, uint160 sqrtPriceX96) external returns (int24 tick);
 
-    struct ModifyLiquidityParams {
-        // the lower and upper tick of the position
-        int24 tickLower;
-        int24 tickUpper;
-        // how to modify the liquidity
-        int256 liquidityDelta;
-        // a value to set if you want unique liquidity positions at the same range
-        bytes32 salt;
-    }
-
     /// @notice Modify the liquidity for the given pool
     /// @dev Poke by calling with a zero liquidityDelta
     /// @param key The pool to modify liquidity in
@@ -139,18 +130,9 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
     /// @dev Note that feesAccrued can be artificially inflated by a malicious actor and integrators should be careful using the value
     /// For pools with a single liquidity position, actors can donate to themselves to inflate feeGrowthGlobal (and consequently feesAccrued)
     /// atomically donating and collecting fees in the same unlockCallback may make the inflated value more extreme
-    function modifyLiquidity(PoolKey memory key, ModifyLiquidityParams memory params, bytes calldata hookData)
+    function modifyLiquidity(PoolKey memory key, PoolOperation.ModifyLiquidityParams memory params, bytes calldata hookData)
         external
         returns (BalanceDelta callerDelta, BalanceDelta feesAccrued);
-
-    struct SwapParams {
-        /// Whether to swap token0 for token1 or vice versa
-        bool zeroForOne;
-        /// The desired input amount if negative (exactIn), or the desired output amount if positive (exactOut)
-        int256 amountSpecified;
-        /// The sqrt price at which, if reached, the swap will stop executing
-        uint160 sqrtPriceLimitX96;
-    }
 
     /// @notice Swap against the given pool
     /// @param key The pool to swap in
@@ -160,7 +142,7 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
     /// @dev Swapping on low liquidity pools may cause unexpected swap amounts when liquidity available is less than amountSpecified.
     /// Additionally note that if interacting with hooks that have the BEFORE_SWAP_RETURNS_DELTA_FLAG or AFTER_SWAP_RETURNS_DELTA_FLAG
     /// the hook may alter the swap input/output. Integrators should perform checks on the returned swapDelta.
-    function swap(PoolKey memory key, SwapParams memory params, bytes calldata hookData)
+    function swap(PoolKey memory key, PoolOperation.SwapParams memory params, bytes calldata hookData)
         external
         returns (BalanceDelta swapDelta);
 

--- a/src/libraries/Hooks.sol
+++ b/src/libraries/Hooks.sol
@@ -8,6 +8,7 @@ import {LPFeeLibrary} from "./LPFeeLibrary.sol";
 import {BalanceDelta, toBalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {ParseBytes} from "./ParseBytes.sol";
 import {CustomRevert} from "./CustomRevert.sol";
 
@@ -194,7 +195,7 @@ library Hooks {
     function beforeModifyLiquidity(
         IHooks self,
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes calldata hookData
     ) internal noSelfCall(self) {
         if (params.liquidityDelta > 0 && self.hasPermission(BEFORE_ADD_LIQUIDITY_FLAG)) {
@@ -208,7 +209,7 @@ library Hooks {
     function afterModifyLiquidity(
         IHooks self,
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         BalanceDelta delta,
         BalanceDelta feesAccrued,
         bytes calldata hookData
@@ -244,7 +245,7 @@ library Hooks {
     }
 
     /// @notice calls beforeSwap hook if permissioned and validates return value
-    function beforeSwap(IHooks self, PoolKey memory key, IPoolManager.SwapParams memory params, bytes calldata hookData)
+    function beforeSwap(IHooks self, PoolKey memory key, PoolOperation.SwapParams memory params, bytes calldata hookData)
         internal
         returns (int256 amountToSwap, BeforeSwapDelta hookReturn, uint24 lpFeeOverride)
     {
@@ -284,7 +285,7 @@ library Hooks {
     function afterSwap(
         IHooks self,
         PoolKey memory key,
-        IPoolManager.SwapParams memory params,
+        PoolOperation.SwapParams memory params,
         BalanceDelta swapDelta,
         bytes calldata hookData,
         BeforeSwapDelta beforeSwapHookReturn

--- a/src/libraries/Hooks.sol
+++ b/src/libraries/Hooks.sol
@@ -8,7 +8,7 @@ import {LPFeeLibrary} from "./LPFeeLibrary.sol";
 import {BalanceDelta, toBalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {ParseBytes} from "./ParseBytes.sol";
 import {CustomRevert} from "./CustomRevert.sol";
 
@@ -195,7 +195,7 @@ library Hooks {
     function beforeModifyLiquidity(
         IHooks self,
         PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
+        ModifyLiquidityParams memory params,
         bytes calldata hookData
     ) internal noSelfCall(self) {
         if (params.liquidityDelta > 0 && self.hasPermission(BEFORE_ADD_LIQUIDITY_FLAG)) {
@@ -209,7 +209,7 @@ library Hooks {
     function afterModifyLiquidity(
         IHooks self,
         PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
+        ModifyLiquidityParams memory params,
         BalanceDelta delta,
         BalanceDelta feesAccrued,
         bytes calldata hookData
@@ -245,7 +245,7 @@ library Hooks {
     }
 
     /// @notice calls beforeSwap hook if permissioned and validates return value
-    function beforeSwap(IHooks self, PoolKey memory key, PoolOperation.SwapParams memory params, bytes calldata hookData)
+    function beforeSwap(IHooks self, PoolKey memory key, SwapParams memory params, bytes calldata hookData)
         internal
         returns (int256 amountToSwap, BeforeSwapDelta hookReturn, uint24 lpFeeOverride)
     {
@@ -285,7 +285,7 @@ library Hooks {
     function afterSwap(
         IHooks self,
         PoolKey memory key,
-        PoolOperation.SwapParams memory params,
+        SwapParams memory params,
         BalanceDelta swapDelta,
         bytes calldata hookData,
         BeforeSwapDelta beforeSwapHookReturn

--- a/src/test/BaseTestHooks.sol
+++ b/src/test/BaseTestHooks.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {IHooks} from "../interfaces/IHooks.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {BeforeSwapDelta} from "../types/BeforeSwapDelta.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
@@ -30,7 +31,7 @@ contract BaseTestHooks is IHooks {
     function beforeAddLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
@@ -39,7 +40,7 @@ contract BaseTestHooks is IHooks {
     function afterAddLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         BalanceDelta, /* delta **/
         BalanceDelta, /* feeDelta **/
         bytes calldata /* hookData **/
@@ -50,7 +51,7 @@ contract BaseTestHooks is IHooks {
     function beforeRemoveLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
@@ -59,7 +60,7 @@ contract BaseTestHooks is IHooks {
     function afterRemoveLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         BalanceDelta, /* delta **/
         BalanceDelta, /* feeDelta **/
         bytes calldata /* hookData **/
@@ -70,7 +71,7 @@ contract BaseTestHooks is IHooks {
     function beforeSwap(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        IPoolManager.SwapParams calldata, /* params **/
+        PoolOperation.SwapParams calldata, /* params **/
         bytes calldata /* hookData **/
     ) external virtual returns (bytes4, BeforeSwapDelta, uint24) {
         revert HookNotImplemented();
@@ -79,7 +80,7 @@ contract BaseTestHooks is IHooks {
     function afterSwap(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        IPoolManager.SwapParams calldata, /* params **/
+        PoolOperation.SwapParams calldata, /* params **/
         BalanceDelta, /* delta **/
         bytes calldata /* hookData **/
     ) external virtual returns (bytes4, int128) {

--- a/src/test/BaseTestHooks.sol
+++ b/src/test/BaseTestHooks.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {IHooks} from "../interfaces/IHooks.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {BeforeSwapDelta} from "../types/BeforeSwapDelta.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
@@ -31,7 +31,7 @@ contract BaseTestHooks is IHooks {
     function beforeAddLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
@@ -40,7 +40,7 @@ contract BaseTestHooks is IHooks {
     function afterAddLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         BalanceDelta, /* delta **/
         BalanceDelta, /* feeDelta **/
         bytes calldata /* hookData **/
@@ -51,7 +51,7 @@ contract BaseTestHooks is IHooks {
     function beforeRemoveLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         bytes calldata /* hookData **/
     ) external virtual returns (bytes4) {
         revert HookNotImplemented();
@@ -60,7 +60,7 @@ contract BaseTestHooks is IHooks {
     function afterRemoveLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         BalanceDelta, /* delta **/
         BalanceDelta, /* feeDelta **/
         bytes calldata /* hookData **/
@@ -71,7 +71,7 @@ contract BaseTestHooks is IHooks {
     function beforeSwap(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        PoolOperation.SwapParams calldata, /* params **/
+        SwapParams calldata, /* params **/
         bytes calldata /* hookData **/
     ) external virtual returns (bytes4, BeforeSwapDelta, uint24) {
         revert HookNotImplemented();
@@ -80,7 +80,7 @@ contract BaseTestHooks is IHooks {
     function afterSwap(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        PoolOperation.SwapParams calldata, /* params **/
+        SwapParams calldata, /* params **/
         BalanceDelta, /* delta **/
         bytes calldata /* hookData **/
     ) external virtual returns (bytes4, int128) {

--- a/src/test/CustomCurveHook.sol
+++ b/src/test/CustomCurveHook.sol
@@ -5,6 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {BeforeSwapDelta, toBeforeSwapDelta} from "../types/BeforeSwapDelta.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -32,7 +33,7 @@ contract CustomCurveHook is BaseTestHooks {
     function beforeSwap(
         address, /* sender **/
         PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
+        PoolOperation.SwapParams calldata params,
         bytes calldata /* hookData **/
     ) external override onlyPoolManager returns (bytes4, BeforeSwapDelta, uint24) {
         (Currency inputCurrency, Currency outputCurrency, uint256 amount) = _getInputOutputAndAmount(key, params);
@@ -50,7 +51,7 @@ contract CustomCurveHook is BaseTestHooks {
     function afterAddLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         BalanceDelta, /* delta **/
         BalanceDelta, /* feeDelta **/
         bytes calldata /* hookData **/
@@ -58,7 +59,7 @@ contract CustomCurveHook is BaseTestHooks {
         revert AddLiquidityDirectToHook();
     }
 
-    function _getInputOutputAndAmount(PoolKey calldata key, IPoolManager.SwapParams calldata params)
+    function _getInputOutputAndAmount(PoolKey calldata key, PoolOperation.SwapParams calldata params)
         internal
         pure
         returns (Currency input, Currency output, uint256 amount)

--- a/src/test/CustomCurveHook.sol
+++ b/src/test/CustomCurveHook.sol
@@ -5,7 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {BeforeSwapDelta, toBeforeSwapDelta} from "../types/BeforeSwapDelta.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -33,7 +33,7 @@ contract CustomCurveHook is BaseTestHooks {
     function beforeSwap(
         address, /* sender **/
         PoolKey calldata key,
-        PoolOperation.SwapParams calldata params,
+        SwapParams calldata params,
         bytes calldata /* hookData **/
     ) external override onlyPoolManager returns (bytes4, BeforeSwapDelta, uint24) {
         (Currency inputCurrency, Currency outputCurrency, uint256 amount) = _getInputOutputAndAmount(key, params);
@@ -51,7 +51,7 @@ contract CustomCurveHook is BaseTestHooks {
     function afterAddLiquidity(
         address, /* sender **/
         PoolKey calldata, /* key **/
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         BalanceDelta, /* delta **/
         BalanceDelta, /* feeDelta **/
         bytes calldata /* hookData **/
@@ -59,7 +59,7 @@ contract CustomCurveHook is BaseTestHooks {
         revert AddLiquidityDirectToHook();
     }
 
-    function _getInputOutputAndAmount(PoolKey calldata key, PoolOperation.SwapParams calldata params)
+    function _getInputOutputAndAmount(PoolKey calldata key, SwapParams calldata params)
         internal
         pure
         returns (Currency input, Currency output, uint256 amount)

--- a/src/test/DeltaReturningHook.sol
+++ b/src/test/DeltaReturningHook.sol
@@ -6,7 +6,7 @@ import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {SwapParams} from "../types/PoolOperation.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
 import {BaseTestHooks} from "./BaseTestHooks.sol";
@@ -47,7 +47,7 @@ contract DeltaReturningHook is BaseTestHooks {
     function beforeSwap(
         address, /* sender **/
         PoolKey calldata key,
-        PoolOperation.SwapParams calldata params,
+        SwapParams calldata params,
         bytes calldata /* hookData **/
     ) external override onlyPoolManager returns (bytes4, BeforeSwapDelta, uint24) {
         (Currency specifiedCurrency, Currency unspecifiedCurrency) = _sortCurrencies(key, params);
@@ -63,7 +63,7 @@ contract DeltaReturningHook is BaseTestHooks {
     function afterSwap(
         address, /* sender **/
         PoolKey calldata key,
-        PoolOperation.SwapParams calldata params,
+        SwapParams calldata params,
         BalanceDelta, /* delta **/
         bytes calldata /* hookData **/
     ) external override onlyPoolManager returns (bytes4, int128) {
@@ -73,7 +73,7 @@ contract DeltaReturningHook is BaseTestHooks {
         return (IHooks.afterSwap.selector, deltaUnspecifiedAfterSwap);
     }
 
-    function _sortCurrencies(PoolKey calldata key, PoolOperation.SwapParams calldata params)
+    function _sortCurrencies(PoolKey calldata key, SwapParams calldata params)
         internal
         pure
         returns (Currency specified, Currency unspecified)

--- a/src/test/DeltaReturningHook.sol
+++ b/src/test/DeltaReturningHook.sol
@@ -6,6 +6,7 @@ import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {CurrencySettler} from "../../test/utils/CurrencySettler.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
 import {BaseTestHooks} from "./BaseTestHooks.sol";
@@ -46,7 +47,7 @@ contract DeltaReturningHook is BaseTestHooks {
     function beforeSwap(
         address, /* sender **/
         PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
+        PoolOperation.SwapParams calldata params,
         bytes calldata /* hookData **/
     ) external override onlyPoolManager returns (bytes4, BeforeSwapDelta, uint24) {
         (Currency specifiedCurrency, Currency unspecifiedCurrency) = _sortCurrencies(key, params);
@@ -62,7 +63,7 @@ contract DeltaReturningHook is BaseTestHooks {
     function afterSwap(
         address, /* sender **/
         PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
+        PoolOperation.SwapParams calldata params,
         BalanceDelta, /* delta **/
         bytes calldata /* hookData **/
     ) external override onlyPoolManager returns (bytes4, int128) {
@@ -72,7 +73,7 @@ contract DeltaReturningHook is BaseTestHooks {
         return (IHooks.afterSwap.selector, deltaUnspecifiedAfterSwap);
     }
 
-    function _sortCurrencies(PoolKey calldata key, IPoolManager.SwapParams calldata params)
+    function _sortCurrencies(PoolKey calldata key, PoolOperation.SwapParams calldata params)
         internal
         pure
         returns (Currency specified, Currency unspecified)

--- a/src/test/DynamicFeesTestHook.sol
+++ b/src/test/DynamicFeesTestHook.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {BaseTestHooks} from "./BaseTestHooks.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {SwapParams} from "../types/PoolOperation.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
@@ -25,7 +25,7 @@ contract DynamicFeesTestHook is BaseTestHooks {
         return IHooks.afterInitialize.selector;
     }
 
-    function beforeSwap(address, PoolKey calldata key, PoolOperation.SwapParams calldata, bytes calldata)
+    function beforeSwap(address, PoolKey calldata key, SwapParams calldata, bytes calldata)
         external
         override
         returns (bytes4, BeforeSwapDelta, uint24)

--- a/src/test/DynamicFeesTestHook.sol
+++ b/src/test/DynamicFeesTestHook.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {BaseTestHooks} from "./BaseTestHooks.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
@@ -24,7 +25,7 @@ contract DynamicFeesTestHook is BaseTestHooks {
         return IHooks.afterInitialize.selector;
     }
 
-    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
+    function beforeSwap(address, PoolKey calldata key, PoolOperation.SwapParams calldata, bytes calldata)
         external
         override
         returns (bytes4, BeforeSwapDelta, uint24)

--- a/src/test/DynamicReturnFeeTestHook.sol
+++ b/src/test/DynamicReturnFeeTestHook.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {BaseTestHooks} from "./BaseTestHooks.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
@@ -22,7 +23,7 @@ contract DynamicReturnFeeTestHook is BaseTestHooks {
         fee = _fee;
     }
 
-    function beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata)
+    function beforeSwap(address, PoolKey calldata, PoolOperation.SwapParams calldata, bytes calldata)
         external
         view
         override

--- a/src/test/DynamicReturnFeeTestHook.sol
+++ b/src/test/DynamicReturnFeeTestHook.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {BaseTestHooks} from "./BaseTestHooks.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {SwapParams} from "../types/PoolOperation.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
@@ -23,7 +23,7 @@ contract DynamicReturnFeeTestHook is BaseTestHooks {
         fee = _fee;
     }
 
-    function beforeSwap(address, PoolKey calldata, PoolOperation.SwapParams calldata, bytes calldata)
+    function beforeSwap(address, PoolKey calldata, SwapParams calldata, bytes calldata)
         external
         view
         override

--- a/src/test/EmptyTestHooks.sol
+++ b/src/test/EmptyTestHooks.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import {Hooks} from "../libraries/Hooks.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
@@ -41,7 +41,7 @@ contract EmptyTestHooks is IHooks {
         return IHooks.afterInitialize.selector;
     }
 
-    function beforeAddLiquidity(address, PoolKey calldata, PoolOperation.ModifyLiquidityParams calldata, bytes calldata)
+    function beforeAddLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata)
         external
         pure
         override
@@ -53,7 +53,7 @@ contract EmptyTestHooks is IHooks {
     function afterAddLiquidity(
         address,
         PoolKey calldata,
-        PoolOperation.ModifyLiquidityParams calldata,
+        ModifyLiquidityParams calldata,
         BalanceDelta,
         BalanceDelta,
         bytes calldata
@@ -61,19 +61,19 @@ contract EmptyTestHooks is IHooks {
         return (IHooks.afterAddLiquidity.selector, BalanceDeltaLibrary.ZERO_DELTA);
     }
 
-    function beforeRemoveLiquidity(
-        address,
-        PoolKey calldata,
-        PoolOperation.ModifyLiquidityParams calldata,
-        bytes calldata
-    ) external pure override returns (bytes4) {
+    function beforeRemoveLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
         return IHooks.beforeRemoveLiquidity.selector;
     }
 
     function afterRemoveLiquidity(
         address,
         PoolKey calldata,
-        PoolOperation.ModifyLiquidityParams calldata,
+        ModifyLiquidityParams calldata,
         BalanceDelta,
         BalanceDelta,
         bytes calldata
@@ -81,7 +81,7 @@ contract EmptyTestHooks is IHooks {
         return (IHooks.afterRemoveLiquidity.selector, BalanceDeltaLibrary.ZERO_DELTA);
     }
 
-    function beforeSwap(address, PoolKey calldata, PoolOperation.SwapParams calldata, bytes calldata)
+    function beforeSwap(address, PoolKey calldata, SwapParams calldata, bytes calldata)
         external
         pure
         override
@@ -90,7 +90,7 @@ contract EmptyTestHooks is IHooks {
         return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
     }
 
-    function afterSwap(address, PoolKey calldata, PoolOperation.SwapParams calldata, BalanceDelta, bytes calldata)
+    function afterSwap(address, PoolKey calldata, SwapParams calldata, BalanceDelta, bytes calldata)
         external
         pure
         override

--- a/src/test/EmptyTestHooks.sol
+++ b/src/test/EmptyTestHooks.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import {Hooks} from "../libraries/Hooks.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "../types/BeforeSwapDelta.sol";
@@ -40,7 +41,7 @@ contract EmptyTestHooks is IHooks {
         return IHooks.afterInitialize.selector;
     }
 
-    function beforeAddLiquidity(address, PoolKey calldata, IPoolManager.ModifyLiquidityParams calldata, bytes calldata)
+    function beforeAddLiquidity(address, PoolKey calldata, PoolOperation.ModifyLiquidityParams calldata, bytes calldata)
         external
         pure
         override
@@ -52,7 +53,7 @@ contract EmptyTestHooks is IHooks {
     function afterAddLiquidity(
         address,
         PoolKey calldata,
-        IPoolManager.ModifyLiquidityParams calldata,
+        PoolOperation.ModifyLiquidityParams calldata,
         BalanceDelta,
         BalanceDelta,
         bytes calldata
@@ -63,7 +64,7 @@ contract EmptyTestHooks is IHooks {
     function beforeRemoveLiquidity(
         address,
         PoolKey calldata,
-        IPoolManager.ModifyLiquidityParams calldata,
+        PoolOperation.ModifyLiquidityParams calldata,
         bytes calldata
     ) external pure override returns (bytes4) {
         return IHooks.beforeRemoveLiquidity.selector;
@@ -72,7 +73,7 @@ contract EmptyTestHooks is IHooks {
     function afterRemoveLiquidity(
         address,
         PoolKey calldata,
-        IPoolManager.ModifyLiquidityParams calldata,
+        PoolOperation.ModifyLiquidityParams calldata,
         BalanceDelta,
         BalanceDelta,
         bytes calldata
@@ -80,7 +81,7 @@ contract EmptyTestHooks is IHooks {
         return (IHooks.afterRemoveLiquidity.selector, BalanceDeltaLibrary.ZERO_DELTA);
     }
 
-    function beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata)
+    function beforeSwap(address, PoolKey calldata, PoolOperation.SwapParams calldata, bytes calldata)
         external
         pure
         override
@@ -89,7 +90,7 @@ contract EmptyTestHooks is IHooks {
         return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
     }
 
-    function afterSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
+    function afterSwap(address, PoolKey calldata, PoolOperation.SwapParams calldata, BalanceDelta, bytes calldata)
         external
         pure
         override

--- a/src/test/FeeTakingHook.sol
+++ b/src/test/FeeTakingHook.sol
@@ -5,6 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {SafeCast} from "../libraries/SafeCast.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, toBalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -33,7 +34,7 @@ contract FeeTakingHook is BaseTestHooks {
     function afterSwap(
         address, /* sender **/
         PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
+        PoolOperation.SwapParams calldata params,
         BalanceDelta delta,
         bytes calldata /* hookData **/
     ) external override onlyPoolManager returns (bytes4, int128) {
@@ -53,7 +54,7 @@ contract FeeTakingHook is BaseTestHooks {
     function afterRemoveLiquidity(
         address, /* sender **/
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         BalanceDelta delta,
         BalanceDelta,
         bytes calldata /* hookData **/
@@ -72,7 +73,7 @@ contract FeeTakingHook is BaseTestHooks {
     function afterAddLiquidity(
         address, /* sender **/
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         BalanceDelta delta,
         BalanceDelta,
         bytes calldata /* hookData **/

--- a/src/test/FeeTakingHook.sol
+++ b/src/test/FeeTakingHook.sol
@@ -5,7 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {SafeCast} from "../libraries/SafeCast.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, toBalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -34,7 +34,7 @@ contract FeeTakingHook is BaseTestHooks {
     function afterSwap(
         address, /* sender **/
         PoolKey calldata key,
-        PoolOperation.SwapParams calldata params,
+        SwapParams calldata params,
         BalanceDelta delta,
         bytes calldata /* hookData **/
     ) external override onlyPoolManager returns (bytes4, int128) {
@@ -54,7 +54,7 @@ contract FeeTakingHook is BaseTestHooks {
     function afterRemoveLiquidity(
         address, /* sender **/
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         BalanceDelta delta,
         BalanceDelta,
         bytes calldata /* hookData **/
@@ -73,7 +73,7 @@ contract FeeTakingHook is BaseTestHooks {
     function afterAddLiquidity(
         address, /* sender **/
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         BalanceDelta delta,
         BalanceDelta,
         bytes calldata /* hookData **/

--- a/src/test/Fuzzers.sol
+++ b/src/test/Fuzzers.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {StdUtils} from "forge-std/StdUtils.sol";
 
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {TickMath} from "../libraries/TickMath.sol";
@@ -132,11 +132,11 @@ contract Fuzzers is StdUtils {
     /// @param key The pool key
     /// @param params IPoolManager.ModifyLiquidityParams Note that these parameters are unbounded
     /// @param sqrtPriceX96 The current sqrt price
-    function createFuzzyLiquidityParams(
-        PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
-        uint160 sqrtPriceX96
-    ) internal pure returns (PoolOperation.ModifyLiquidityParams memory result) {
+    function createFuzzyLiquidityParams(PoolKey memory key, ModifyLiquidityParams memory params, uint160 sqrtPriceX96)
+        internal
+        pure
+        returns (ModifyLiquidityParams memory result)
+    {
         (result.tickLower, result.tickUpper) = boundTicks(key, params.tickLower, params.tickUpper);
         int256 liquidityDeltaFromAmounts =
             getLiquidityDeltaFromAmounts(result.tickLower, result.tickUpper, sqrtPriceX96);
@@ -146,10 +146,10 @@ contract Fuzzers is StdUtils {
     // Creates liquidity parameters with a stricter bound. Should be used if multiple positions being initialized on the pool, with potential for tick overlap.
     function createFuzzyLiquidityParamsWithTightBound(
         PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
+        ModifyLiquidityParams memory params,
         uint160 sqrtPriceX96,
         uint256 maxPositions
-    ) internal pure returns (PoolOperation.ModifyLiquidityParams memory result) {
+    ) internal pure returns (ModifyLiquidityParams memory result) {
         (result.tickLower, result.tickUpper) = boundTicks(key, params.tickLower, params.tickUpper);
         int256 liquidityDeltaFromAmounts =
             getLiquidityDeltaFromAmounts(result.tickLower, result.tickUpper, sqrtPriceX96);
@@ -161,10 +161,10 @@ contract Fuzzers is StdUtils {
     function createFuzzyLiquidity(
         PoolModifyLiquidityTest modifyLiquidityRouter,
         PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
+        ModifyLiquidityParams memory params,
         uint160 sqrtPriceX96,
         bytes memory hookData
-    ) internal returns (PoolOperation.ModifyLiquidityParams memory result, BalanceDelta delta) {
+    ) internal returns (ModifyLiquidityParams memory result, BalanceDelta delta) {
         result = createFuzzyLiquidityParams(key, params, sqrtPriceX96);
         delta = modifyLiquidityRouter.modifyLiquidity(key, result, hookData);
     }
@@ -173,11 +173,11 @@ contract Fuzzers is StdUtils {
     function createFuzzyLiquidityWithTightBound(
         PoolModifyLiquidityTest modifyLiquidityRouter,
         PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
+        ModifyLiquidityParams memory params,
         uint160 sqrtPriceX96,
         bytes memory hookData,
         uint256 maxPositions
-    ) internal returns (PoolOperation.ModifyLiquidityParams memory result, BalanceDelta delta) {
+    ) internal returns (ModifyLiquidityParams memory result, BalanceDelta delta) {
         result = createFuzzyLiquidityParamsWithTightBound(key, params, sqrtPriceX96, maxPositions);
         delta = modifyLiquidityRouter.modifyLiquidity(key, result, hookData);
     }

--- a/src/test/Fuzzers.sol
+++ b/src/test/Fuzzers.sol
@@ -5,6 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {StdUtils} from "forge-std/StdUtils.sol";
 
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {TickMath} from "../libraries/TickMath.sol";
@@ -133,9 +134,9 @@ contract Fuzzers is StdUtils {
     /// @param sqrtPriceX96 The current sqrt price
     function createFuzzyLiquidityParams(
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         uint160 sqrtPriceX96
-    ) internal pure returns (IPoolManager.ModifyLiquidityParams memory result) {
+    ) internal pure returns (PoolOperation.ModifyLiquidityParams memory result) {
         (result.tickLower, result.tickUpper) = boundTicks(key, params.tickLower, params.tickUpper);
         int256 liquidityDeltaFromAmounts =
             getLiquidityDeltaFromAmounts(result.tickLower, result.tickUpper, sqrtPriceX96);
@@ -145,10 +146,10 @@ contract Fuzzers is StdUtils {
     // Creates liquidity parameters with a stricter bound. Should be used if multiple positions being initialized on the pool, with potential for tick overlap.
     function createFuzzyLiquidityParamsWithTightBound(
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         uint160 sqrtPriceX96,
         uint256 maxPositions
-    ) internal pure returns (IPoolManager.ModifyLiquidityParams memory result) {
+    ) internal pure returns (PoolOperation.ModifyLiquidityParams memory result) {
         (result.tickLower, result.tickUpper) = boundTicks(key, params.tickLower, params.tickUpper);
         int256 liquidityDeltaFromAmounts =
             getLiquidityDeltaFromAmounts(result.tickLower, result.tickUpper, sqrtPriceX96);
@@ -160,10 +161,10 @@ contract Fuzzers is StdUtils {
     function createFuzzyLiquidity(
         PoolModifyLiquidityTest modifyLiquidityRouter,
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         uint160 sqrtPriceX96,
         bytes memory hookData
-    ) internal returns (IPoolManager.ModifyLiquidityParams memory result, BalanceDelta delta) {
+    ) internal returns (PoolOperation.ModifyLiquidityParams memory result, BalanceDelta delta) {
         result = createFuzzyLiquidityParams(key, params, sqrtPriceX96);
         delta = modifyLiquidityRouter.modifyLiquidity(key, result, hookData);
     }
@@ -172,11 +173,11 @@ contract Fuzzers is StdUtils {
     function createFuzzyLiquidityWithTightBound(
         PoolModifyLiquidityTest modifyLiquidityRouter,
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         uint160 sqrtPriceX96,
         bytes memory hookData,
         uint256 maxPositions
-    ) internal returns (IPoolManager.ModifyLiquidityParams memory result, BalanceDelta delta) {
+    ) internal returns (PoolOperation.ModifyLiquidityParams memory result, BalanceDelta delta) {
         result = createFuzzyLiquidityParamsWithTightBound(key, params, sqrtPriceX96, maxPositions);
         delta = modifyLiquidityRouter.modifyLiquidity(key, result, hookData);
     }

--- a/src/test/LPFeeTakingHook.sol
+++ b/src/test/LPFeeTakingHook.sol
@@ -5,7 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {SafeCast} from "../libraries/SafeCast.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, toBalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -32,7 +32,7 @@ contract LPFeeTakingHook is BaseTestHooks {
     function afterRemoveLiquidity(
         address, /* sender **/
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         BalanceDelta,
         BalanceDelta feeDelta,
         bytes calldata /* hookData **/
@@ -49,7 +49,7 @@ contract LPFeeTakingHook is BaseTestHooks {
     function afterAddLiquidity(
         address, /* sender **/
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata, /* params **/
+        ModifyLiquidityParams calldata, /* params **/
         BalanceDelta,
         BalanceDelta feeDelta,
         bytes calldata /* hookData **/

--- a/src/test/LPFeeTakingHook.sol
+++ b/src/test/LPFeeTakingHook.sol
@@ -5,6 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {SafeCast} from "../libraries/SafeCast.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, toBalanceDelta} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -31,7 +32,7 @@ contract LPFeeTakingHook is BaseTestHooks {
     function afterRemoveLiquidity(
         address, /* sender **/
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         BalanceDelta,
         BalanceDelta feeDelta,
         bytes calldata /* hookData **/
@@ -48,7 +49,7 @@ contract LPFeeTakingHook is BaseTestHooks {
     function afterAddLiquidity(
         address, /* sender **/
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata, /* params **/
+        PoolOperation.ModifyLiquidityParams calldata, /* params **/
         BalanceDelta,
         BalanceDelta feeDelta,
         bytes calldata /* hookData **/

--- a/src/test/MockHooks.sol
+++ b/src/test/MockHooks.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import {Hooks} from "../libraries/Hooks.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {PoolId} from "../types/PoolId.sol";
@@ -42,7 +43,7 @@ contract MockHooks is IHooks {
     function beforeAddLiquidity(
         address,
         PoolKey calldata,
-        IPoolManager.ModifyLiquidityParams calldata,
+        PoolOperation.ModifyLiquidityParams calldata,
         bytes calldata hookData
     ) external override returns (bytes4) {
         beforeAddLiquidityData = hookData;
@@ -53,7 +54,7 @@ contract MockHooks is IHooks {
     function afterAddLiquidity(
         address,
         PoolKey calldata,
-        IPoolManager.ModifyLiquidityParams calldata,
+        PoolOperation.ModifyLiquidityParams calldata,
         BalanceDelta,
         BalanceDelta,
         bytes calldata hookData
@@ -66,7 +67,7 @@ contract MockHooks is IHooks {
     function beforeRemoveLiquidity(
         address,
         PoolKey calldata,
-        IPoolManager.ModifyLiquidityParams calldata,
+        PoolOperation.ModifyLiquidityParams calldata,
         bytes calldata hookData
     ) external override returns (bytes4) {
         beforeRemoveLiquidityData = hookData;
@@ -77,7 +78,7 @@ contract MockHooks is IHooks {
     function afterRemoveLiquidity(
         address,
         PoolKey calldata,
-        IPoolManager.ModifyLiquidityParams calldata,
+        PoolOperation.ModifyLiquidityParams calldata,
         BalanceDelta,
         BalanceDelta,
         bytes calldata hookData
@@ -87,7 +88,7 @@ contract MockHooks is IHooks {
         return (returnValues[selector] == bytes4(0) ? selector : returnValues[selector], BalanceDeltaLibrary.ZERO_DELTA);
     }
 
-    function beforeSwap(address, PoolKey calldata, IPoolManager.SwapParams calldata, bytes calldata hookData)
+    function beforeSwap(address, PoolKey calldata, PoolOperation.SwapParams calldata, bytes calldata hookData)
         external
         override
         returns (bytes4, BeforeSwapDelta, uint24)
@@ -104,7 +105,7 @@ contract MockHooks is IHooks {
     function afterSwap(
         address,
         PoolKey calldata,
-        IPoolManager.SwapParams calldata,
+        PoolOperation.SwapParams calldata,
         BalanceDelta,
         bytes calldata hookData
     ) external override returns (bytes4, int128) {

--- a/src/test/MockHooks.sol
+++ b/src/test/MockHooks.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import {Hooks} from "../libraries/Hooks.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {PoolId} from "../types/PoolId.sol";
@@ -40,12 +40,11 @@ contract MockHooks is IHooks {
         return returnValues[selector] == bytes4(0) ? selector : returnValues[selector];
     }
 
-    function beforeAddLiquidity(
-        address,
-        PoolKey calldata,
-        PoolOperation.ModifyLiquidityParams calldata,
-        bytes calldata hookData
-    ) external override returns (bytes4) {
+    function beforeAddLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata hookData)
+        external
+        override
+        returns (bytes4)
+    {
         beforeAddLiquidityData = hookData;
         bytes4 selector = MockHooks.beforeAddLiquidity.selector;
         return returnValues[selector] == bytes4(0) ? selector : returnValues[selector];
@@ -54,7 +53,7 @@ contract MockHooks is IHooks {
     function afterAddLiquidity(
         address,
         PoolKey calldata,
-        PoolOperation.ModifyLiquidityParams calldata,
+        ModifyLiquidityParams calldata,
         BalanceDelta,
         BalanceDelta,
         bytes calldata hookData
@@ -64,12 +63,11 @@ contract MockHooks is IHooks {
         return (returnValues[selector] == bytes4(0) ? selector : returnValues[selector], BalanceDeltaLibrary.ZERO_DELTA);
     }
 
-    function beforeRemoveLiquidity(
-        address,
-        PoolKey calldata,
-        PoolOperation.ModifyLiquidityParams calldata,
-        bytes calldata hookData
-    ) external override returns (bytes4) {
+    function beforeRemoveLiquidity(address, PoolKey calldata, ModifyLiquidityParams calldata, bytes calldata hookData)
+        external
+        override
+        returns (bytes4)
+    {
         beforeRemoveLiquidityData = hookData;
         bytes4 selector = MockHooks.beforeRemoveLiquidity.selector;
         return returnValues[selector] == bytes4(0) ? selector : returnValues[selector];
@@ -78,7 +76,7 @@ contract MockHooks is IHooks {
     function afterRemoveLiquidity(
         address,
         PoolKey calldata,
-        PoolOperation.ModifyLiquidityParams calldata,
+        ModifyLiquidityParams calldata,
         BalanceDelta,
         BalanceDelta,
         bytes calldata hookData
@@ -88,7 +86,7 @@ contract MockHooks is IHooks {
         return (returnValues[selector] == bytes4(0) ? selector : returnValues[selector], BalanceDeltaLibrary.ZERO_DELTA);
     }
 
-    function beforeSwap(address, PoolKey calldata, PoolOperation.SwapParams calldata, bytes calldata hookData)
+    function beforeSwap(address, PoolKey calldata, SwapParams calldata, bytes calldata hookData)
         external
         override
         returns (bytes4, BeforeSwapDelta, uint24)
@@ -102,13 +100,11 @@ contract MockHooks is IHooks {
         );
     }
 
-    function afterSwap(
-        address,
-        PoolKey calldata,
-        PoolOperation.SwapParams calldata,
-        BalanceDelta,
-        bytes calldata hookData
-    ) external override returns (bytes4, int128) {
+    function afterSwap(address, PoolKey calldata, SwapParams calldata, BalanceDelta, bytes calldata hookData)
+        external
+        override
+        returns (bytes4, int128)
+    {
         afterSwapData = hookData;
         bytes4 selector = MockHooks.afterSwap.selector;
         return (returnValues[selector] == bytes4(0) ? selector : returnValues[selector], 0);

--- a/src/test/PoolModifyLiquidityTest.sol
+++ b/src/test/PoolModifyLiquidityTest.sol
@@ -5,7 +5,7 @@ import {CurrencyLibrary, Currency} from "../types/Currency.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "../types/PoolOperation.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
@@ -24,23 +24,23 @@ contract PoolModifyLiquidityTest is PoolTestBase {
     struct CallbackData {
         address sender;
         PoolKey key;
-        PoolOperation.ModifyLiquidityParams params;
+        ModifyLiquidityParams params;
         bytes hookData;
         bool settleUsingBurn;
         bool takeClaims;
     }
 
-    function modifyLiquidity(
-        PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
-        bytes memory hookData
-    ) external payable returns (BalanceDelta delta) {
+    function modifyLiquidity(PoolKey memory key, ModifyLiquidityParams memory params, bytes memory hookData)
+        external
+        payable
+        returns (BalanceDelta delta)
+    {
         delta = modifyLiquidity(key, params, hookData, false, false);
     }
 
     function modifyLiquidity(
         PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
+        ModifyLiquidityParams memory params,
         bytes memory hookData,
         bool settleUsingBurn,
         bool takeClaims

--- a/src/test/PoolModifyLiquidityTest.sol
+++ b/src/test/PoolModifyLiquidityTest.sol
@@ -5,6 +5,7 @@ import {CurrencyLibrary, Currency} from "../types/Currency.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
@@ -23,7 +24,7 @@ contract PoolModifyLiquidityTest is PoolTestBase {
     struct CallbackData {
         address sender;
         PoolKey key;
-        IPoolManager.ModifyLiquidityParams params;
+        PoolOperation.ModifyLiquidityParams params;
         bytes hookData;
         bool settleUsingBurn;
         bool takeClaims;
@@ -31,7 +32,7 @@ contract PoolModifyLiquidityTest is PoolTestBase {
 
     function modifyLiquidity(
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes memory hookData
     ) external payable returns (BalanceDelta delta) {
         delta = modifyLiquidity(key, params, hookData, false, false);
@@ -39,7 +40,7 @@ contract PoolModifyLiquidityTest is PoolTestBase {
 
     function modifyLiquidity(
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes memory hookData,
         bool settleUsingBurn,
         bool takeClaims

--- a/src/test/PoolModifyLiquidityTestNoChecks.sol
+++ b/src/test/PoolModifyLiquidityTestNoChecks.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import {CurrencyLibrary, Currency} from "../types/Currency.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
@@ -22,23 +22,23 @@ contract PoolModifyLiquidityTestNoChecks is PoolTestBase {
     struct CallbackData {
         address sender;
         PoolKey key;
-        PoolOperation.ModifyLiquidityParams params;
+        ModifyLiquidityParams params;
         bytes hookData;
         bool settleUsingBurn;
         bool takeClaims;
     }
 
-    function modifyLiquidity(
-        PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
-        bytes memory hookData
-    ) external payable returns (BalanceDelta delta) {
+    function modifyLiquidity(PoolKey memory key, ModifyLiquidityParams memory params, bytes memory hookData)
+        external
+        payable
+        returns (BalanceDelta delta)
+    {
         delta = modifyLiquidity(key, params, hookData, false, false);
     }
 
     function modifyLiquidity(
         PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
+        ModifyLiquidityParams memory params,
         bytes memory hookData,
         bool settleUsingBurn,
         bool takeClaims

--- a/src/test/PoolModifyLiquidityTestNoChecks.sol
+++ b/src/test/PoolModifyLiquidityTestNoChecks.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import {CurrencyLibrary, Currency} from "../types/Currency.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
@@ -21,7 +22,7 @@ contract PoolModifyLiquidityTestNoChecks is PoolTestBase {
     struct CallbackData {
         address sender;
         PoolKey key;
-        IPoolManager.ModifyLiquidityParams params;
+        PoolOperation.ModifyLiquidityParams params;
         bytes hookData;
         bool settleUsingBurn;
         bool takeClaims;
@@ -29,7 +30,7 @@ contract PoolModifyLiquidityTestNoChecks is PoolTestBase {
 
     function modifyLiquidity(
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes memory hookData
     ) external payable returns (BalanceDelta delta) {
         delta = modifyLiquidity(key, params, hookData, false, false);
@@ -37,7 +38,7 @@ contract PoolModifyLiquidityTestNoChecks is PoolTestBase {
 
     function modifyLiquidity(
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes memory hookData,
         bool settleUsingBurn,
         bool takeClaims

--- a/src/test/PoolNestedActionsTest.sol
+++ b/src/test/PoolNestedActionsTest.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "../interfaces/callback/IUnlockCallback.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {Constants} from "../../test/utils/Constants.sol";
 import {Test} from "forge-std/Test.sol";
@@ -73,14 +74,14 @@ contract NestedActionExecutor is Test, PoolTestBase {
 
     error KeyNotSet();
 
-    IPoolManager.ModifyLiquidityParams internal ADD_LIQUIDITY_PARAMS =
-        IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
+    PoolOperation.ModifyLiquidityParams internal ADD_LIQUIDITY_PARAMS =
+        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
 
-    IPoolManager.ModifyLiquidityParams internal REMOVE_LIQUIDITY_PARAMS =
-        IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
+    PoolOperation.ModifyLiquidityParams internal REMOVE_LIQUIDITY_PARAMS =
+        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
 
-    IPoolManager.SwapParams internal SWAP_PARAMS =
-        IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: Constants.SQRT_PRICE_1_2});
+    PoolOperation.SwapParams internal SWAP_PARAMS =
+        PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: Constants.SQRT_PRICE_1_2});
 
     uint256 internal DONATE_AMOUNT0 = 12345e6;
     uint256 internal DONATE_AMOUNT1 = 98765e4;

--- a/src/test/PoolNestedActionsTest.sol
+++ b/src/test/PoolNestedActionsTest.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "../interfaces/callback/IUnlockCallback.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {Constants} from "../../test/utils/Constants.sol";
 import {Test} from "forge-std/Test.sol";
@@ -74,14 +74,14 @@ contract NestedActionExecutor is Test, PoolTestBase {
 
     error KeyNotSet();
 
-    PoolOperation.ModifyLiquidityParams internal ADD_LIQUIDITY_PARAMS =
-        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
+    ModifyLiquidityParams internal ADD_LIQUIDITY_PARAMS =
+        ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
 
-    PoolOperation.ModifyLiquidityParams internal REMOVE_LIQUIDITY_PARAMS =
-        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
+    ModifyLiquidityParams internal REMOVE_LIQUIDITY_PARAMS =
+        ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
 
-    PoolOperation.SwapParams internal SWAP_PARAMS =
-        PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: Constants.SQRT_PRICE_1_2});
+    SwapParams internal SWAP_PARAMS =
+        SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: Constants.SQRT_PRICE_1_2});
 
     uint256 internal DONATE_AMOUNT0 = 12345e6;
     uint256 internal DONATE_AMOUNT1 = 98765e4;

--- a/src/test/PoolSwapTest.sol
+++ b/src/test/PoolSwapTest.sol
@@ -5,6 +5,7 @@ import {CurrencyLibrary, Currency} from "../types/Currency.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
@@ -22,7 +23,7 @@ contract PoolSwapTest is PoolTestBase {
         address sender;
         TestSettings testSettings;
         PoolKey key;
-        IPoolManager.SwapParams params;
+        PoolOperation.SwapParams params;
         bytes hookData;
     }
 
@@ -33,7 +34,7 @@ contract PoolSwapTest is PoolTestBase {
 
     function swap(
         PoolKey memory key,
-        IPoolManager.SwapParams memory params,
+        PoolOperation.SwapParams memory params,
         TestSettings memory testSettings,
         bytes memory hookData
     ) external payable returns (BalanceDelta delta) {

--- a/src/test/PoolSwapTest.sol
+++ b/src/test/PoolSwapTest.sol
@@ -5,7 +5,7 @@ import {CurrencyLibrary, Currency} from "../types/Currency.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {SwapParams} from "../types/PoolOperation.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
@@ -23,7 +23,7 @@ contract PoolSwapTest is PoolTestBase {
         address sender;
         TestSettings testSettings;
         PoolKey key;
-        PoolOperation.SwapParams params;
+        SwapParams params;
         bytes hookData;
     }
 
@@ -32,12 +32,11 @@ contract PoolSwapTest is PoolTestBase {
         bool settleUsingBurn;
     }
 
-    function swap(
-        PoolKey memory key,
-        PoolOperation.SwapParams memory params,
-        TestSettings memory testSettings,
-        bytes memory hookData
-    ) external payable returns (BalanceDelta delta) {
+    function swap(PoolKey memory key, SwapParams memory params, TestSettings memory testSettings, bytes memory hookData)
+        external
+        payable
+        returns (BalanceDelta delta)
+    {
         delta = abi.decode(
             manager.unlock(abi.encode(CallbackData(msg.sender, testSettings, key, params, hookData))), (BalanceDelta)
         );

--- a/src/test/ProxyPoolManager.sol
+++ b/src/test/ProxyPoolManager.sol
@@ -8,7 +8,7 @@ import {Position} from "../libraries/Position.sol";
 import {LPFeeLibrary} from "../libraries/LPFeeLibrary.sol";
 import {Currency} from "../types/Currency.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {TickMath} from "../libraries/TickMath.sol";
 import {NoDelegateCall} from "../NoDelegateCall.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
@@ -95,11 +95,12 @@ contract ProxyPoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909
     }
 
     /// @inheritdoc IPoolManager
-    function modifyLiquidity(
-        PoolKey memory key,
-        PoolOperation.ModifyLiquidityParams memory params,
-        bytes calldata hookData
-    ) external onlyWhenUnlocked noDelegateCall returns (BalanceDelta callerDelta, BalanceDelta feesAccrued) {
+    function modifyLiquidity(PoolKey memory key, ModifyLiquidityParams memory params, bytes calldata hookData)
+        external
+        onlyWhenUnlocked
+        noDelegateCall
+        returns (BalanceDelta callerDelta, BalanceDelta feesAccrued)
+    {
         bytes memory result = _delegateCall(
             _delegateManager, abi.encodeWithSelector(this.modifyLiquidity.selector, key, params, hookData)
         );
@@ -108,7 +109,7 @@ contract ProxyPoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909
     }
 
     /// @inheritdoc IPoolManager
-    function swap(PoolKey memory key, PoolOperation.SwapParams memory params, bytes calldata hookData)
+    function swap(PoolKey memory key, SwapParams memory params, bytes calldata hookData)
         external
         onlyWhenUnlocked
         noDelegateCall

--- a/src/test/ProxyPoolManager.sol
+++ b/src/test/ProxyPoolManager.sol
@@ -8,6 +8,7 @@ import {Position} from "../libraries/Position.sol";
 import {LPFeeLibrary} from "../libraries/LPFeeLibrary.sol";
 import {Currency} from "../types/Currency.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {TickMath} from "../libraries/TickMath.sol";
 import {NoDelegateCall} from "../NoDelegateCall.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
@@ -96,7 +97,7 @@ contract ProxyPoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909
     /// @inheritdoc IPoolManager
     function modifyLiquidity(
         PoolKey memory key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes calldata hookData
     ) external onlyWhenUnlocked noDelegateCall returns (BalanceDelta callerDelta, BalanceDelta feesAccrued) {
         bytes memory result = _delegateCall(
@@ -107,7 +108,7 @@ contract ProxyPoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909
     }
 
     /// @inheritdoc IPoolManager
-    function swap(PoolKey memory key, IPoolManager.SwapParams memory params, bytes calldata hookData)
+    function swap(PoolKey memory key, PoolOperation.SwapParams memory params, bytes calldata hookData)
         external
         onlyWhenUnlocked
         noDelegateCall

--- a/src/test/SkipCallsTestHook.sol
+++ b/src/test/SkipCallsTestHook.sol
@@ -5,7 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {BaseTestHooks} from "./BaseTestHooks.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -47,7 +47,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function beforeAddLiquidity(
         address,
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata params,
+        ModifyLiquidityParams calldata params,
         bytes calldata hookData
     ) external override returns (bytes4) {
         counter++;
@@ -58,7 +58,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function afterAddLiquidity(
         address,
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata params,
+        ModifyLiquidityParams calldata params,
         BalanceDelta,
         BalanceDelta,
         bytes calldata hookData
@@ -71,7 +71,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function beforeRemoveLiquidity(
         address,
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata params,
+        ModifyLiquidityParams calldata params,
         bytes calldata hookData
     ) external override returns (bytes4) {
         counter++;
@@ -82,7 +82,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function afterRemoveLiquidity(
         address,
         PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams calldata params,
+        ModifyLiquidityParams calldata params,
         BalanceDelta,
         BalanceDelta,
         bytes calldata hookData
@@ -92,7 +92,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
         return (IHooks.afterRemoveLiquidity.selector, BalanceDeltaLibrary.ZERO_DELTA);
     }
 
-    function beforeSwap(address, PoolKey calldata key, PoolOperation.SwapParams calldata params, bytes calldata hookData)
+    function beforeSwap(address, PoolKey calldata key, SwapParams calldata params, bytes calldata hookData)
         external
         override
         returns (bytes4, BeforeSwapDelta, uint24)
@@ -102,13 +102,11 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
         return (IHooks.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
     }
 
-    function afterSwap(
-        address,
-        PoolKey calldata key,
-        PoolOperation.SwapParams calldata params,
-        BalanceDelta,
-        bytes calldata hookData
-    ) external override returns (bytes4, int128) {
+    function afterSwap(address, PoolKey calldata key, SwapParams calldata params, BalanceDelta, bytes calldata hookData)
+        external
+        override
+        returns (bytes4, int128)
+    {
         counter++;
         _swap(key, params, hookData);
         return (IHooks.afterSwap.selector, 0);
@@ -140,7 +138,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
         IPoolManager(manager).initialize(key, sqrtPriceX96);
     }
 
-    function _swap(PoolKey calldata key, PoolOperation.SwapParams memory params, bytes calldata hookData) public {
+    function _swap(PoolKey calldata key, SwapParams memory params, bytes calldata hookData) public {
         IPoolManager(manager).swap(key, params, hookData);
         address payer = abi.decode(hookData, (address));
         int256 delta0 = IPoolManager(manager).currencyDelta(address(this), key.currency0);
@@ -151,11 +149,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
         key.currency1.take(manager, payer, uint256(delta1), false);
     }
 
-    function _addLiquidity(
-        PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams memory params,
-        bytes calldata hookData
-    ) public {
+    function _addLiquidity(PoolKey calldata key, ModifyLiquidityParams memory params, bytes calldata hookData) public {
         IPoolManager(manager).modifyLiquidity(key, params, hookData);
         address payer = abi.decode(hookData, (address));
         int256 delta0 = IPoolManager(manager).currencyDelta(address(this), key.currency0);
@@ -168,14 +162,12 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
         key.currency1.settle(manager, payer, uint256(-delta1), false);
     }
 
-    function _removeLiquidity(
-        PoolKey calldata key,
-        PoolOperation.ModifyLiquidityParams memory params,
-        bytes calldata hookData
-    ) public {
+    function _removeLiquidity(PoolKey calldata key, ModifyLiquidityParams memory params, bytes calldata hookData)
+        public
+    {
         // first hook needs to add liquidity for itself
-        PoolOperation.ModifyLiquidityParams memory newParams =
-            PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
+        ModifyLiquidityParams memory newParams =
+            ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
         IPoolManager(manager).modifyLiquidity(key, newParams, hookData);
         // hook removes liquidity
         IPoolManager(manager).modifyLiquidity(key, params, hookData);

--- a/src/test/SkipCallsTestHook.sol
+++ b/src/test/SkipCallsTestHook.sol
@@ -5,6 +5,7 @@ import {Hooks} from "../libraries/Hooks.sol";
 import {BaseTestHooks} from "./BaseTestHooks.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "../types/BalanceDelta.sol";
 import {Currency} from "../types/Currency.sol";
@@ -46,7 +47,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function beforeAddLiquidity(
         address,
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params,
+        PoolOperation.ModifyLiquidityParams calldata params,
         bytes calldata hookData
     ) external override returns (bytes4) {
         counter++;
@@ -57,7 +58,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function afterAddLiquidity(
         address,
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params,
+        PoolOperation.ModifyLiquidityParams calldata params,
         BalanceDelta,
         BalanceDelta,
         bytes calldata hookData
@@ -70,7 +71,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function beforeRemoveLiquidity(
         address,
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params,
+        PoolOperation.ModifyLiquidityParams calldata params,
         bytes calldata hookData
     ) external override returns (bytes4) {
         counter++;
@@ -81,7 +82,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function afterRemoveLiquidity(
         address,
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams calldata params,
+        PoolOperation.ModifyLiquidityParams calldata params,
         BalanceDelta,
         BalanceDelta,
         bytes calldata hookData
@@ -91,7 +92,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
         return (IHooks.afterRemoveLiquidity.selector, BalanceDeltaLibrary.ZERO_DELTA);
     }
 
-    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata params, bytes calldata hookData)
+    function beforeSwap(address, PoolKey calldata key, PoolOperation.SwapParams calldata params, bytes calldata hookData)
         external
         override
         returns (bytes4, BeforeSwapDelta, uint24)
@@ -104,7 +105,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
     function afterSwap(
         address,
         PoolKey calldata key,
-        IPoolManager.SwapParams calldata params,
+        PoolOperation.SwapParams calldata params,
         BalanceDelta,
         bytes calldata hookData
     ) external override returns (bytes4, int128) {
@@ -139,7 +140,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
         IPoolManager(manager).initialize(key, sqrtPriceX96);
     }
 
-    function _swap(PoolKey calldata key, IPoolManager.SwapParams memory params, bytes calldata hookData) public {
+    function _swap(PoolKey calldata key, PoolOperation.SwapParams memory params, bytes calldata hookData) public {
         IPoolManager(manager).swap(key, params, hookData);
         address payer = abi.decode(hookData, (address));
         int256 delta0 = IPoolManager(manager).currencyDelta(address(this), key.currency0);
@@ -152,7 +153,7 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
 
     function _addLiquidity(
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes calldata hookData
     ) public {
         IPoolManager(manager).modifyLiquidity(key, params, hookData);
@@ -169,12 +170,12 @@ contract SkipCallsTestHook is BaseTestHooks, Test {
 
     function _removeLiquidity(
         PoolKey calldata key,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         bytes calldata hookData
     ) public {
         // first hook needs to add liquidity for itself
-        IPoolManager.ModifyLiquidityParams memory newParams =
-            IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
+        PoolOperation.ModifyLiquidityParams memory newParams =
+            PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
         IPoolManager(manager).modifyLiquidity(key, newParams, hookData);
         // hook removes liquidity
         IPoolManager(manager).modifyLiquidity(key, params, hookData);

--- a/src/test/SwapRouterNoChecks.sol
+++ b/src/test/SwapRouterNoChecks.sol
@@ -5,6 +5,7 @@ import {Currency} from "../types/Currency.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {PoolKey} from "../types/PoolKey.sol";
+import {PoolOperation} from "../types/PoolOperation.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
@@ -21,10 +22,10 @@ contract SwapRouterNoChecks is PoolTestBase {
     struct CallbackData {
         address sender;
         PoolKey key;
-        IPoolManager.SwapParams params;
+        PoolOperation.SwapParams params;
     }
 
-    function swap(PoolKey memory key, IPoolManager.SwapParams memory params) external payable {
+    function swap(PoolKey memory key, PoolOperation.SwapParams memory params) external payable {
         manager.unlock(abi.encode(CallbackData(msg.sender, key, params)));
     }
 

--- a/src/test/SwapRouterNoChecks.sol
+++ b/src/test/SwapRouterNoChecks.sol
@@ -5,7 +5,7 @@ import {Currency} from "../types/Currency.sol";
 import {IPoolManager} from "../interfaces/IPoolManager.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 import {PoolKey} from "../types/PoolKey.sol";
-import {PoolOperation} from "../types/PoolOperation.sol";
+import {SwapParams} from "../types/PoolOperation.sol";
 import {IHooks} from "../interfaces/IHooks.sol";
 import {Hooks} from "../libraries/Hooks.sol";
 import {PoolTestBase} from "./PoolTestBase.sol";
@@ -22,10 +22,10 @@ contract SwapRouterNoChecks is PoolTestBase {
     struct CallbackData {
         address sender;
         PoolKey key;
-        PoolOperation.SwapParams params;
+        SwapParams params;
     }
 
-    function swap(PoolKey memory key, PoolOperation.SwapParams memory params) external payable {
+    function swap(PoolKey memory key, SwapParams memory params) external payable {
         manager.unlock(abi.encode(CallbackData(msg.sender, key, params)));
     }
 

--- a/src/types/PoolOperation.sol
+++ b/src/types/PoolOperation.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {PoolKey} from "../types/PoolKey.sol";
+import {BalanceDelta} from "../types/BalanceDelta.sol";
+
+/// @notice Common types used by both IPoolManager and IHooks
+interface PoolOperation {
+    struct ModifyLiquidityParams {
+        // the lower and upper tick of the position
+        int24 tickLower;
+        int24 tickUpper;
+        // how to modify the liquidity
+        int256 liquidityDelta;
+        // a value to set if you want unique liquidity positions at the same range
+        bytes32 salt;
+    }
+
+    struct SwapParams {
+        /// Whether to swap token0 for token1 or vice versa
+        bool zeroForOne;
+        /// The desired input amount if negative (exactIn), or the desired output amount if positive (exactOut)
+        int256 amountSpecified;
+        /// The sqrt price at which, if reached, the swap will stop executing
+        uint160 sqrtPriceLimitX96;
+    }
+}

--- a/src/types/PoolOperation.sol
+++ b/src/types/PoolOperation.sol
@@ -4,24 +4,23 @@ pragma solidity ^0.8.24;
 import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 
-/// @notice Common types used by both IPoolManager and IHooks
-interface PoolOperation {
-    struct ModifyLiquidityParams {
-        // the lower and upper tick of the position
-        int24 tickLower;
-        int24 tickUpper;
-        // how to modify the liquidity
-        int256 liquidityDelta;
-        // a value to set if you want unique liquidity positions at the same range
-        bytes32 salt;
-    }
+/// @notice Parameter struct for `ModifyLiquidity` pool operations
+struct ModifyLiquidityParams {
+    // the lower and upper tick of the position
+    int24 tickLower;
+    int24 tickUpper;
+    // how to modify the liquidity
+    int256 liquidityDelta;
+    // a value to set if you want unique liquidity positions at the same range
+    bytes32 salt;
+}
 
-    struct SwapParams {
-        /// Whether to swap token0 for token1 or vice versa
-        bool zeroForOne;
-        /// The desired input amount if negative (exactIn), or the desired output amount if positive (exactOut)
-        int256 amountSpecified;
-        /// The sqrt price at which, if reached, the swap will stop executing
-        uint160 sqrtPriceLimitX96;
-    }
+/// @notice Parameter struct for `Swap` pool operations
+struct SwapParams {
+    /// Whether to swap token0 for token1 or vice versa
+    bool zeroForOne;
+    /// The desired input amount if negative (exactIn), or the desired output amount if positive (exactOut)
+    int256 amountSpecified;
+    /// The sqrt price at which, if reached, the swap will stop executing
+    uint160 sqrtPriceLimitX96;
 }

--- a/test/CustomAccounting.t.sol
+++ b/test/CustomAccounting.t.sol
@@ -11,6 +11,7 @@ import {IHooks} from "../src/interfaces/IHooks.sol";
 import {Hooks} from "../src/libraries/Hooks.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 import {PoolId} from "../src/types/PoolId.sol";
+import {PoolOperation} from "../src/types/PoolOperation.sol";
 import {IPoolManager} from "../src/interfaces/IPoolManager.sol";
 import {Currency} from "../src/types/Currency.sol";
 import {BalanceDelta} from "../src/types/BalanceDelta.sol";
@@ -77,7 +78,7 @@ contract CustomAccountingTest is Test, Deployers {
         uint256 amountToSwap = 1000;
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
+        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
             zeroForOne: true,
             amountSpecified: -int256(amountToSwap),
             sqrtPriceLimitX96: SQRT_PRICE_1_2
@@ -100,7 +101,7 @@ contract CustomAccountingTest is Test, Deployers {
         uint256 amountToSwap = 1000;
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
+        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
             zeroForOne: true,
             amountSpecified: int256(amountToSwap),
             sqrtPriceLimitX96: SQRT_PRICE_1_2
@@ -126,7 +127,7 @@ contract CustomAccountingTest is Test, Deployers {
         uint256 amountToSwap = 123456;
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
+        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
             zeroForOne: true,
             amountSpecified: -int256(amountToSwap),
             sqrtPriceLimitX96: SQRT_PRICE_1_2
@@ -152,7 +153,7 @@ contract CustomAccountingTest is Test, Deployers {
         uint256 amountToSwap = 123456;
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
+        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
             zeroForOne: true,
             amountSpecified: int256(amountToSwap),
             sqrtPriceLimitX96: SQRT_PRICE_1_2
@@ -196,7 +197,7 @@ contract CustomAccountingTest is Test, Deployers {
         // setup swap variables
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
+        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
             zeroForOne: zeroForOne,
             amountSpecified: amountSpecified,
             sqrtPriceLimitX96: (zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT)

--- a/test/CustomAccounting.t.sol
+++ b/test/CustomAccounting.t.sol
@@ -11,7 +11,7 @@ import {IHooks} from "../src/interfaces/IHooks.sol";
 import {Hooks} from "../src/libraries/Hooks.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 import {PoolId} from "../src/types/PoolId.sol";
-import {PoolOperation} from "../src/types/PoolOperation.sol";
+import {SwapParams} from "../src/types/PoolOperation.sol";
 import {IPoolManager} from "../src/interfaces/IPoolManager.sol";
 import {Currency} from "../src/types/Currency.sol";
 import {BalanceDelta} from "../src/types/BalanceDelta.sol";
@@ -78,11 +78,8 @@ contract CustomAccountingTest is Test, Deployers {
         uint256 amountToSwap = 1000;
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
-            zeroForOne: true,
-            amountSpecified: -int256(amountToSwap),
-            sqrtPriceLimitX96: SQRT_PRICE_1_2
-        });
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: -int256(amountToSwap), sqrtPriceLimitX96: SQRT_PRICE_1_2});
         swapRouter.swap(key, params, testSettings, ZERO_BYTES);
         vm.snapshotGasLastCall("swap CA fee on unspecified");
 
@@ -101,11 +98,8 @@ contract CustomAccountingTest is Test, Deployers {
         uint256 amountToSwap = 1000;
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
-            zeroForOne: true,
-            amountSpecified: int256(amountToSwap),
-            sqrtPriceLimitX96: SQRT_PRICE_1_2
-        });
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: int256(amountToSwap), sqrtPriceLimitX96: SQRT_PRICE_1_2});
         swapRouter.swap(key, params, testSettings, ZERO_BYTES);
 
         // input is 1002 for output of 1000 with this much liquidity available
@@ -127,11 +121,8 @@ contract CustomAccountingTest is Test, Deployers {
         uint256 amountToSwap = 123456;
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
-            zeroForOne: true,
-            amountSpecified: -int256(amountToSwap),
-            sqrtPriceLimitX96: SQRT_PRICE_1_2
-        });
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: -int256(amountToSwap), sqrtPriceLimitX96: SQRT_PRICE_1_2});
         swapRouter.swap(key, params, testSettings, ZERO_BYTES);
         vm.snapshotGasLastCall("swap CA custom curve + swap noop");
 
@@ -153,11 +144,8 @@ contract CustomAccountingTest is Test, Deployers {
         uint256 amountToSwap = 123456;
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
-            zeroForOne: true,
-            amountSpecified: int256(amountToSwap),
-            sqrtPriceLimitX96: SQRT_PRICE_1_2
-        });
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: int256(amountToSwap), sqrtPriceLimitX96: SQRT_PRICE_1_2});
         swapRouter.swap(key, params, testSettings, ZERO_BYTES);
 
         // the custom curve hook is 1-1 linear
@@ -197,7 +185,7 @@ contract CustomAccountingTest is Test, Deployers {
         // setup swap variables
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
+        SwapParams memory params = SwapParams({
             zeroForOne: zeroForOne,
             amountSpecified: amountSpecified,
             sqrtPriceLimitX96: (zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT)

--- a/test/DynamicFees.t.sol
+++ b/test/DynamicFees.t.sol
@@ -10,6 +10,7 @@ import {IPoolManager} from "../src/interfaces/IPoolManager.sol";
 import {IProtocolFees} from "../src/interfaces/IProtocolFees.sol";
 import {IHooks} from "../src/interfaces/IHooks.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
+import {PoolOperation} from "../src/types/PoolOperation.sol";
 import {PoolManager} from "../src/PoolManager.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 import {Deployers} from "./utils/Deployers.sol";
@@ -197,8 +198,8 @@ contract TestDynamicFees is Test, Deployers {
 
         dynamicFeesHooks.setFee(500000);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -215,8 +216,8 @@ contract TestDynamicFees is Test, Deployers {
 
         dynamicFeesHooks.setFee(1000000);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -232,8 +233,8 @@ contract TestDynamicFees is Test, Deployers {
         vm.prank(feeController);
         manager.setProtocolFee(key, 1000);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -249,8 +250,8 @@ contract TestDynamicFees is Test, Deployers {
         vm.prank(feeController);
         manager.setProtocolFee(key, 1000);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -1000, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -1000, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -298,7 +299,7 @@ contract TestDynamicFees is Test, Deployers {
         vm.prank(feeController);
         manager.setProtocolFee(key, protocolFee);
 
-        IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
+        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
             zeroForOne: true,
             amountSpecified: amountSpecified,
             sqrtPriceLimitX96: SQRT_PRICE_1_2

--- a/test/DynamicFees.t.sol
+++ b/test/DynamicFees.t.sol
@@ -10,7 +10,7 @@ import {IPoolManager} from "../src/interfaces/IPoolManager.sol";
 import {IProtocolFees} from "../src/interfaces/IProtocolFees.sol";
 import {IHooks} from "../src/interfaces/IHooks.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
-import {PoolOperation} from "../src/types/PoolOperation.sol";
+import {SwapParams} from "../src/types/PoolOperation.sol";
 import {PoolManager} from "../src/PoolManager.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 import {Deployers} from "./utils/Deployers.sol";
@@ -198,8 +198,8 @@ contract TestDynamicFees is Test, Deployers {
 
         dynamicFeesHooks.setFee(500000);
 
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -216,8 +216,8 @@ contract TestDynamicFees is Test, Deployers {
 
         dynamicFeesHooks.setFee(1000000);
 
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -233,8 +233,8 @@ contract TestDynamicFees is Test, Deployers {
         vm.prank(feeController);
         manager.setProtocolFee(key, 1000);
 
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -250,8 +250,8 @@ contract TestDynamicFees is Test, Deployers {
         vm.prank(feeController);
         manager.setProtocolFee(key, 1000);
 
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -1000, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: -1000, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
@@ -299,11 +299,8 @@ contract TestDynamicFees is Test, Deployers {
         vm.prank(feeController);
         manager.setProtocolFee(key, protocolFee);
 
-        PoolOperation.SwapParams memory params = PoolOperation.SwapParams({
-            zeroForOne: true,
-            amountSpecified: amountSpecified,
-            sqrtPriceLimitX96: SQRT_PRICE_1_2
-        });
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: amountSpecified, sqrtPriceLimitX96: SQRT_PRICE_1_2});
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 

--- a/test/ModifyLiquidity.t.sol
+++ b/test/ModifyLiquidity.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import {Test} from "forge-std/Test.sol";
 import {Deployers} from "./utils/Deployers.sol";
 import {PoolKey} from "src/types/PoolKey.sol";
-import {PoolOperation} from "src/types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "src/types/PoolOperation.sol";
 import {IPoolManager} from "src/interfaces/IPoolManager.sol";
 import {IHooks} from "src/interfaces/IHooks.sol";
 import {Position} from "src/libraries/Position.sol";
@@ -31,11 +31,11 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
 
     int128 constant ONE_PIP = 1e6;
 
-    PoolOperation.ModifyLiquidityParams public LIQ_PARAM_NO_SALT =
-        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
+    ModifyLiquidityParams public LIQ_PARAM_NO_SALT =
+        ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
 
-    PoolOperation.ModifyLiquidityParams public LIQ_PARAM_SALT =
-        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: SALT});
+    ModifyLiquidityParams public LIQ_PARAM_SALT =
+        ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: SALT});
 
     function setUp() public {
         deployFreshManagerAndRouters();
@@ -51,13 +51,12 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
     /// forge-config: pr.fuzz.runs = 10
     /// forge-config: ci.fuzz.runs = 500
     /// forge-config: debug.fuzz.runs = 10
-    function test_ffi_fuzz_addLiquidity_defaultPool_ReturnsCorrectLiquidityDelta(
-        PoolOperation.ModifyLiquidityParams memory paramSeed
-    ) public {
+    function test_ffi_fuzz_addLiquidity_defaultPool_ReturnsCorrectLiquidityDelta(ModifyLiquidityParams memory paramSeed)
+        public
+    {
         // Sanitize the fuzzed params to get valid tickLower, tickUpper, and liquidityDelta.
         // We use SQRT_PRICE_1_1 because the simpleKey pool has initial sqrtPrice of SQRT_PRICE_1_1.
-        PoolOperation.ModifyLiquidityParams memory params =
-            createFuzzyLiquidityParams(simpleKey, paramSeed, SQRT_PRICE_1_1);
+        ModifyLiquidityParams memory params = createFuzzyLiquidityParams(simpleKey, paramSeed, SQRT_PRICE_1_1);
 
         logParams(params);
 
@@ -78,7 +77,7 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         // Set the params to add random amount of liquidity to random tick boundary.
         int24 tickUpper = TickMath.MAX_TICK_SPACING * 4;
         int24 tickLower = TickMath.MAX_TICK_SPACING * -9;
-        PoolOperation.ModifyLiquidityParams memory params = PoolOperation.ModifyLiquidityParams({
+        ModifyLiquidityParams memory params = ModifyLiquidityParams({
             tickLower: tickLower,
             tickUpper: tickUpper,
             liquidityDelta: 16787899214600939458,
@@ -102,7 +101,7 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         // Set the params to add random amount of liquidity to random tick boundary.
         int24 tickUpper = TickMath.MIN_TICK_SPACING * 17;
         int24 tickLower = TickMath.MIN_TICK_SPACING * 9;
-        PoolOperation.ModifyLiquidityParams memory params = PoolOperation.ModifyLiquidityParams({
+        ModifyLiquidityParams memory params = ModifyLiquidityParams({
             tickLower: tickLower,
             tickUpper: tickUpper,
             liquidityDelta: 922871614499955267459963,
@@ -119,10 +118,7 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         _checkError(delta.amount1(), jsDelta1, "amount1 is off by more than one pip");
     }
 
-    function _modifyLiquidityJS(PoolId poolId, PoolOperation.ModifyLiquidityParams memory params)
-        public
-        returns (int128, int128)
-    {
+    function _modifyLiquidityJS(PoolId poolId, ModifyLiquidityParams memory params) public returns (int128, int128) {
         (uint256 price, int24 tick,,) = manager.getSlot0(poolId);
 
         string memory jsParameters = string(
@@ -258,8 +254,8 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         MockERC20(Currency.unwrap(currency0)).approve(address(modifyLiquidityRouter2), Constants.MAX_UINT256);
         MockERC20(Currency.unwrap(currency1)).approve(address(modifyLiquidityRouter2), Constants.MAX_UINT256);
 
-        PoolOperation.ModifyLiquidityParams memory LIQ_PARAM_SALT_2 =
-            PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 2e18, salt: SALT});
+        ModifyLiquidityParams memory LIQ_PARAM_SALT_2 =
+            ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 2e18, salt: SALT});
 
         // Get the uninitialized positions and assert they have no liquidity.
         (uint128 liquiditySalt,,) = manager.getPositionInfo(

--- a/test/ModifyLiquidity.t.sol
+++ b/test/ModifyLiquidity.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {Test} from "forge-std/Test.sol";
 import {Deployers} from "./utils/Deployers.sol";
 import {PoolKey} from "src/types/PoolKey.sol";
+import {PoolOperation} from "src/types/PoolOperation.sol";
 import {IPoolManager} from "src/interfaces/IPoolManager.sol";
 import {IHooks} from "src/interfaces/IHooks.sol";
 import {Position} from "src/libraries/Position.sol";
@@ -30,11 +31,11 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
 
     int128 constant ONE_PIP = 1e6;
 
-    IPoolManager.ModifyLiquidityParams public LIQ_PARAM_NO_SALT =
-        IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
+    PoolOperation.ModifyLiquidityParams public LIQ_PARAM_NO_SALT =
+        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
 
-    IPoolManager.ModifyLiquidityParams public LIQ_PARAM_SALT =
-        IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: SALT});
+    PoolOperation.ModifyLiquidityParams public LIQ_PARAM_SALT =
+        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: SALT});
 
     function setUp() public {
         deployFreshManagerAndRouters();
@@ -51,11 +52,11 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
     /// forge-config: ci.fuzz.runs = 500
     /// forge-config: debug.fuzz.runs = 10
     function test_ffi_fuzz_addLiquidity_defaultPool_ReturnsCorrectLiquidityDelta(
-        IPoolManager.ModifyLiquidityParams memory paramSeed
+        PoolOperation.ModifyLiquidityParams memory paramSeed
     ) public {
         // Sanitize the fuzzed params to get valid tickLower, tickUpper, and liquidityDelta.
         // We use SQRT_PRICE_1_1 because the simpleKey pool has initial sqrtPrice of SQRT_PRICE_1_1.
-        IPoolManager.ModifyLiquidityParams memory params =
+        PoolOperation.ModifyLiquidityParams memory params =
             createFuzzyLiquidityParams(simpleKey, paramSeed, SQRT_PRICE_1_1);
 
         logParams(params);
@@ -77,7 +78,7 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         // Set the params to add random amount of liquidity to random tick boundary.
         int24 tickUpper = TickMath.MAX_TICK_SPACING * 4;
         int24 tickLower = TickMath.MAX_TICK_SPACING * -9;
-        IPoolManager.ModifyLiquidityParams memory params = IPoolManager.ModifyLiquidityParams({
+        PoolOperation.ModifyLiquidityParams memory params = PoolOperation.ModifyLiquidityParams({
             tickLower: tickLower,
             tickUpper: tickUpper,
             liquidityDelta: 16787899214600939458,
@@ -101,7 +102,7 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         // Set the params to add random amount of liquidity to random tick boundary.
         int24 tickUpper = TickMath.MIN_TICK_SPACING * 17;
         int24 tickLower = TickMath.MIN_TICK_SPACING * 9;
-        IPoolManager.ModifyLiquidityParams memory params = IPoolManager.ModifyLiquidityParams({
+        PoolOperation.ModifyLiquidityParams memory params = PoolOperation.ModifyLiquidityParams({
             tickLower: tickLower,
             tickUpper: tickUpper,
             liquidityDelta: 922871614499955267459963,
@@ -118,7 +119,7 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         _checkError(delta.amount1(), jsDelta1, "amount1 is off by more than one pip");
     }
 
-    function _modifyLiquidityJS(PoolId poolId, IPoolManager.ModifyLiquidityParams memory params)
+    function _modifyLiquidityJS(PoolId poolId, PoolOperation.ModifyLiquidityParams memory params)
         public
         returns (int128, int128)
     {
@@ -257,8 +258,8 @@ contract ModifyLiquidityTest is Test, Logger, Deployers, JavascriptFfi, Fuzzers 
         MockERC20(Currency.unwrap(currency0)).approve(address(modifyLiquidityRouter2), Constants.MAX_UINT256);
         MockERC20(Currency.unwrap(currency1)).approve(address(modifyLiquidityRouter2), Constants.MAX_UINT256);
 
-        IPoolManager.ModifyLiquidityParams memory LIQ_PARAM_SALT_2 =
-            IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 2e18, salt: SALT});
+        PoolOperation.ModifyLiquidityParams memory LIQ_PARAM_SALT_2 =
+            PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 2e18, salt: SALT});
 
         // Get the uninitialized positions and assert they have no liquidity.
         (uint128 liquiditySalt,,) = manager.getPositionInfo(

--- a/test/PoolManager.swap.t.sol
+++ b/test/PoolManager.swap.t.sol
@@ -11,7 +11,7 @@ import {IPoolManager} from "../src/interfaces/IPoolManager.sol";
 import {BalanceDelta, BalanceDeltaLibrary, toBalanceDelta} from "../src/types/BalanceDelta.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
-import {PoolOperation} from "../src/types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../src/types/PoolOperation.sol";
 import {SqrtPriceMath} from "../src/libraries/SqrtPriceMath.sol";
 import {TickMath} from "../src/libraries/TickMath.sol";
 import {SafeCast} from "../src/libraries/SafeCast.sol";
@@ -54,7 +54,7 @@ abstract contract V3Fuzzer is V3Helper, Deployers, Fuzzers, IUniswapV3MintCallba
         int256 liquidityDeltaUnbound,
         bool tight
     ) internal {
-        PoolOperation.ModifyLiquidityParams memory v4LiquidityParams = PoolOperation.ModifyLiquidityParams({
+        ModifyLiquidityParams memory v4LiquidityParams = ModifyLiquidityParams({
             tickLower: lowerTickUnsanitized,
             tickUpper: upperTickUnsanitized,
             liquidityDelta: liquidityDeltaUnbound,
@@ -100,7 +100,7 @@ abstract contract V3Fuzzer is V3Helper, Deployers, Fuzzers, IUniswapV3MintCallba
             overflows = true;
         }
         // v4 swap
-        PoolOperation.SwapParams memory swapParams = PoolOperation.SwapParams({
+        SwapParams memory swapParams = SwapParams({
             zeroForOne: zeroForOne,
             amountSpecified: amountSpecified,
             sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT

--- a/test/PoolManager.swap.t.sol
+++ b/test/PoolManager.swap.t.sol
@@ -11,6 +11,7 @@ import {IPoolManager} from "../src/interfaces/IPoolManager.sol";
 import {BalanceDelta, BalanceDeltaLibrary, toBalanceDelta} from "../src/types/BalanceDelta.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
+import {PoolOperation} from "../src/types/PoolOperation.sol";
 import {SqrtPriceMath} from "../src/libraries/SqrtPriceMath.sol";
 import {TickMath} from "../src/libraries/TickMath.sol";
 import {SafeCast} from "../src/libraries/SafeCast.sol";
@@ -53,7 +54,7 @@ abstract contract V3Fuzzer is V3Helper, Deployers, Fuzzers, IUniswapV3MintCallba
         int256 liquidityDeltaUnbound,
         bool tight
     ) internal {
-        IPoolManager.ModifyLiquidityParams memory v4LiquidityParams = IPoolManager.ModifyLiquidityParams({
+        PoolOperation.ModifyLiquidityParams memory v4LiquidityParams = PoolOperation.ModifyLiquidityParams({
             tickLower: lowerTickUnsanitized,
             tickUpper: upperTickUnsanitized,
             liquidityDelta: liquidityDeltaUnbound,
@@ -99,7 +100,7 @@ abstract contract V3Fuzzer is V3Helper, Deployers, Fuzzers, IUniswapV3MintCallba
             overflows = true;
         }
         // v4 swap
-        IPoolManager.SwapParams memory swapParams = IPoolManager.SwapParams({
+        PoolOperation.SwapParams memory swapParams = PoolOperation.SwapParams({
             zeroForOne: zeroForOne,
             amountSpecified: amountSpecified,
             sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT

--- a/test/PoolManager.t.sol
+++ b/test/PoolManager.t.sol
@@ -15,6 +15,7 @@ import {MockHooks} from "../src/test/MockHooks.sol";
 import {MockContract} from "../src/test/MockContract.sol";
 import {EmptyTestHooks} from "../src/test/EmptyTestHooks.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
+import {PoolOperation} from "../src/types/PoolOperation.sol";
 import {PoolModifyLiquidityTest} from "../src/test/PoolModifyLiquidityTest.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "../src/types/BalanceDelta.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
@@ -399,23 +400,23 @@ contract PoolManagerTest is Test, Deployers {
     }
 
     function test_addLiquidity_gas() public {
-        IPoolManager.ModifyLiquidityParams memory uniqueParams =
-            IPoolManager.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
+        PoolOperation.ModifyLiquidityParams memory uniqueParams =
+            PoolOperation.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
         vm.snapshotGasLastCall("simple addLiquidity");
     }
 
     function test_addLiquidity_secondAdditionSameRange_gas() public {
-        IPoolManager.ModifyLiquidityParams memory uniqueParams =
-            IPoolManager.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
+        PoolOperation.ModifyLiquidityParams memory uniqueParams =
+            PoolOperation.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
         vm.snapshotGasLastCall("simple addLiquidity second addition same range");
     }
 
     function test_removeLiquidity_gas() public {
-        IPoolManager.ModifyLiquidityParams memory uniqueParams =
-            IPoolManager.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
+        PoolOperation.ModifyLiquidityParams memory uniqueParams =
+            PoolOperation.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
         // add some liquidity to remove
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
 
@@ -426,8 +427,8 @@ contract PoolManagerTest is Test, Deployers {
 
     function test_removeLiquidity_someLiquidityRemains_gas() public {
         // add double the liquidity to remove
-        IPoolManager.ModifyLiquidityParams memory uniqueParams =
-            IPoolManager.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
+        PoolOperation.ModifyLiquidityParams memory uniqueParams =
+            PoolOperation.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
 
         uniqueParams.liquidityDelta /= -2;
@@ -482,8 +483,8 @@ contract PoolManagerTest is Test, Deployers {
         sqrtPriceX96 = uint160(bound(sqrtPriceX96, TickMath.MIN_SQRT_PRICE, TickMath.MAX_SQRT_PRICE - 1));
 
         key.fee = 100;
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: sqrtPriceX96});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: sqrtPriceX96});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
@@ -566,8 +567,8 @@ contract PoolManagerTest is Test, Deployers {
 
         (key,) = initPoolAndAddLiquidity(currency0, currency1, mockHooks, 100, SQRT_PRICE_1_1);
 
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 10, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory swapParams =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 10, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
@@ -594,8 +595,8 @@ contract PoolManagerTest is Test, Deployers {
 
         (key,) = initPoolAndAddLiquidity(currency0, currency1, mockHooks, 100, SQRT_PRICE_1_1);
 
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -10, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory swapParams =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -10, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
@@ -647,8 +648,8 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        PoolOperation.SwapParams memory swapParams =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
         testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         swapRouter.swap(key, swapParams, testSettings, ZERO_BYTES);
@@ -669,8 +670,8 @@ contract PoolManagerTest is Test, Deployers {
     }
 
     function test_swap_mint6909IfNativeOutputNotTaken_gas() public {
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: false, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_2_1});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: false, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_2_1});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
@@ -701,8 +702,8 @@ contract PoolManagerTest is Test, Deployers {
         manager.setOperator(address(swapRouter), true);
 
         // swap from currency1 to currency0 again, using 6909s as input tokens
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: false, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_4_1});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: false, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_4_1});
         testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: true});
 
         vm.expectEmit();
@@ -715,8 +716,8 @@ contract PoolManagerTest is Test, Deployers {
     }
 
     function test_swap_burnNative6909AsInput_gas() public {
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: false, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_2_1});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: false, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_2_1});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
@@ -734,7 +735,7 @@ contract PoolManagerTest is Test, Deployers {
         manager.setOperator(address(swapRouter), true);
 
         // swap from currency0 to currency1, using 6909s as input tokens
-        params = IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        params = PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_1_4});
         testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: true});
 
         vm.expectEmit();
@@ -755,8 +756,8 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
 
         swapRouter.swap(key, params, testSettings, ZERO_BYTES);
         vm.snapshotGasLastCall("swap against liquidity");
@@ -768,8 +769,8 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap{value: 1 ether}(nativeKey, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        IPoolManager.SwapParams memory params =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        PoolOperation.SwapParams memory params =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
 
         swapRouter.swap{value: 1 ether}(nativeKey, params, testSettings, ZERO_BYTES);
         vm.snapshotGasLastCall("swap against liquidity with native token");
@@ -792,7 +793,7 @@ contract PoolManagerTest is Test, Deployers {
         assertEq(slot0ProtocolFee, protocolFee);
 
         // Add liquidity - Fees dont accrue for positive liquidity delta.
-        IPoolManager.ModifyLiquidityParams memory params = LIQUIDITY_PARAMS;
+        PoolOperation.ModifyLiquidityParams memory params = LIQUIDITY_PARAMS;
         modifyLiquidityRouter.modifyLiquidity(key, params, ZERO_BYTES);
 
         assertEq(manager.protocolFeesAccrued(currency0), 0);
@@ -809,8 +810,8 @@ contract PoolManagerTest is Test, Deployers {
         params.liquidityDelta = LIQUIDITY_PARAMS.liquidityDelta;
         modifyLiquidityRouter.modifyLiquidity(key, params, ZERO_BYTES);
 
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams(false, amountSpecified, TickMath.MAX_SQRT_PRICE - 1);
+        PoolOperation.SwapParams memory swapParams =
+            PoolOperation.SwapParams(false, amountSpecified, TickMath.MAX_SQRT_PRICE - 1);
         BalanceDelta delta = swapRouter.swap(key, swapParams, PoolSwapTest.TestSettings(false, false), ZERO_BYTES);
         uint256 expectedProtocolFee =
             uint256(uint128(-delta.amount1())) * protocolFee1 / ProtocolFeeLibrary.PIPS_DENOMINATOR;
@@ -1052,7 +1053,7 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap(
             key,
-            IPoolManager.SwapParams(true, -10000, SQRT_PRICE_1_2),
+            PoolOperation.SwapParams(true, -10000, SQRT_PRICE_1_2),
             PoolSwapTest.TestSettings(false, false),
             ZERO_BYTES
         );
@@ -1081,7 +1082,7 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap(
             key,
-            IPoolManager.SwapParams(true, 10000, SQRT_PRICE_1_2),
+            PoolOperation.SwapParams(true, 10000, SQRT_PRICE_1_2),
             PoolSwapTest.TestSettings(false, false),
             ZERO_BYTES
         );
@@ -1109,7 +1110,7 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap(
             key,
-            IPoolManager.SwapParams(false, -10000, TickMath.MAX_SQRT_PRICE - 1),
+            PoolOperation.SwapParams(false, -10000, TickMath.MAX_SQRT_PRICE - 1),
             PoolSwapTest.TestSettings(false, false),
             ZERO_BYTES
         );
@@ -1138,7 +1139,7 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap{value: 10000}(
             nativeKey,
-            IPoolManager.SwapParams(true, -10000, SQRT_PRICE_1_2),
+            PoolOperation.SwapParams(true, -10000, SQRT_PRICE_1_2),
             PoolSwapTest.TestSettings(false, false),
             ZERO_BYTES
         );
@@ -1168,7 +1169,7 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap{value: 10000}(
             nativeKey,
-            IPoolManager.SwapParams(true, -10000, SQRT_PRICE_1_2),
+            PoolOperation.SwapParams(true, -10000, SQRT_PRICE_1_2),
             PoolSwapTest.TestSettings(false, false),
             ZERO_BYTES
         );
@@ -1235,15 +1236,15 @@ contract PoolManagerTest is Test, Deployers {
     //     manager.initialize(key, SQRT_PRICE_1_1);
 
     //     // populate feeGrowthGlobalX128 struct w/ modify + swap
-    //     modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(-120, 120, 5 ether, 0));
+    //     modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-120, 120, 5 ether, 0));
     //     swapRouter.swap(
     //         key,
-    //         IPoolManager.SwapParams(false, 1 ether, TickMath.MAX_SQRT_PRICE - 1),
+    //         PoolOperation.SwapParams(false, 1 ether, TickMath.MAX_SQRT_PRICE - 1),
     //         PoolSwapTest.TestSettings(true, true)
     //     );
     //     swapRouter.swap(
     //         key,
-    //         IPoolManager.SwapParams(true, 5 ether, TickMath.MIN_SQRT_PRICE + 1),
+    //         PoolOperation.SwapParams(true, 5 ether, TickMath.MIN_SQRT_PRICE + 1),
     //         PoolSwapTest.TestSettings(true, true)
     //     );
 

--- a/test/PoolManager.t.sol
+++ b/test/PoolManager.t.sol
@@ -15,7 +15,7 @@ import {MockHooks} from "../src/test/MockHooks.sol";
 import {MockContract} from "../src/test/MockContract.sol";
 import {EmptyTestHooks} from "../src/test/EmptyTestHooks.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
-import {PoolOperation} from "../src/types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../src/types/PoolOperation.sol";
 import {PoolModifyLiquidityTest} from "../src/test/PoolModifyLiquidityTest.sol";
 import {BalanceDelta, BalanceDeltaLibrary} from "../src/types/BalanceDelta.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
@@ -400,23 +400,23 @@ contract PoolManagerTest is Test, Deployers {
     }
 
     function test_addLiquidity_gas() public {
-        PoolOperation.ModifyLiquidityParams memory uniqueParams =
-            PoolOperation.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
+        ModifyLiquidityParams memory uniqueParams =
+            ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
         vm.snapshotGasLastCall("simple addLiquidity");
     }
 
     function test_addLiquidity_secondAdditionSameRange_gas() public {
-        PoolOperation.ModifyLiquidityParams memory uniqueParams =
-            PoolOperation.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
+        ModifyLiquidityParams memory uniqueParams =
+            ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
         vm.snapshotGasLastCall("simple addLiquidity second addition same range");
     }
 
     function test_removeLiquidity_gas() public {
-        PoolOperation.ModifyLiquidityParams memory uniqueParams =
-            PoolOperation.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
+        ModifyLiquidityParams memory uniqueParams =
+            ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
         // add some liquidity to remove
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
 
@@ -427,8 +427,8 @@ contract PoolManagerTest is Test, Deployers {
 
     function test_removeLiquidity_someLiquidityRemains_gas() public {
         // add double the liquidity to remove
-        PoolOperation.ModifyLiquidityParams memory uniqueParams =
-            PoolOperation.ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
+        ModifyLiquidityParams memory uniqueParams =
+            ModifyLiquidityParams({tickLower: -300, tickUpper: -180, liquidityDelta: 1e18, salt: 0});
         modifyLiquidityNoChecks.modifyLiquidity(key, uniqueParams, ZERO_BYTES);
 
         uniqueParams.liquidityDelta /= -2;
@@ -483,8 +483,8 @@ contract PoolManagerTest is Test, Deployers {
         sqrtPriceX96 = uint160(bound(sqrtPriceX96, TickMath.MIN_SQRT_PRICE, TickMath.MAX_SQRT_PRICE - 1));
 
         key.fee = 100;
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: sqrtPriceX96});
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: sqrtPriceX96});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
@@ -567,8 +567,8 @@ contract PoolManagerTest is Test, Deployers {
 
         (key,) = initPoolAndAddLiquidity(currency0, currency1, mockHooks, 100, SQRT_PRICE_1_1);
 
-        PoolOperation.SwapParams memory swapParams =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 10, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory swapParams =
+            SwapParams({zeroForOne: true, amountSpecified: 10, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
@@ -595,8 +595,8 @@ contract PoolManagerTest is Test, Deployers {
 
         (key,) = initPoolAndAddLiquidity(currency0, currency1, mockHooks, 100, SQRT_PRICE_1_1);
 
-        PoolOperation.SwapParams memory swapParams =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -10, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory swapParams =
+            SwapParams({zeroForOne: true, amountSpecified: -10, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
@@ -648,8 +648,8 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        PoolOperation.SwapParams memory swapParams =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        SwapParams memory swapParams =
+            SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
         testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
 
         swapRouter.swap(key, swapParams, testSettings, ZERO_BYTES);
@@ -670,8 +670,8 @@ contract PoolManagerTest is Test, Deployers {
     }
 
     function test_swap_mint6909IfNativeOutputNotTaken_gas() public {
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: false, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_2_1});
+        SwapParams memory params =
+            SwapParams({zeroForOne: false, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_2_1});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
@@ -702,8 +702,8 @@ contract PoolManagerTest is Test, Deployers {
         manager.setOperator(address(swapRouter), true);
 
         // swap from currency1 to currency0 again, using 6909s as input tokens
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: false, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_4_1});
+        SwapParams memory params =
+            SwapParams({zeroForOne: false, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_4_1});
         testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: true});
 
         vm.expectEmit();
@@ -716,8 +716,8 @@ contract PoolManagerTest is Test, Deployers {
     }
 
     function test_swap_burnNative6909AsInput_gas() public {
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: false, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_2_1});
+        SwapParams memory params =
+            SwapParams({zeroForOne: false, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_2_1});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: true, settleUsingBurn: false});
@@ -735,7 +735,7 @@ contract PoolManagerTest is Test, Deployers {
         manager.setOperator(address(swapRouter), true);
 
         // swap from currency0 to currency1, using 6909s as input tokens
-        params = PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        params = SwapParams({zeroForOne: true, amountSpecified: 25, sqrtPriceLimitX96: SQRT_PRICE_1_4});
         testSettings = PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: true});
 
         vm.expectEmit();
@@ -756,8 +756,8 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap(key, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
 
         swapRouter.swap(key, params, testSettings, ZERO_BYTES);
         vm.snapshotGasLastCall("swap against liquidity");
@@ -769,8 +769,8 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap{value: 1 ether}(nativeKey, SWAP_PARAMS, testSettings, ZERO_BYTES);
 
-        PoolOperation.SwapParams memory params =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
+        SwapParams memory params =
+            SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_4});
 
         swapRouter.swap{value: 1 ether}(nativeKey, params, testSettings, ZERO_BYTES);
         vm.snapshotGasLastCall("swap against liquidity with native token");
@@ -793,7 +793,7 @@ contract PoolManagerTest is Test, Deployers {
         assertEq(slot0ProtocolFee, protocolFee);
 
         // Add liquidity - Fees dont accrue for positive liquidity delta.
-        PoolOperation.ModifyLiquidityParams memory params = LIQUIDITY_PARAMS;
+        ModifyLiquidityParams memory params = LIQUIDITY_PARAMS;
         modifyLiquidityRouter.modifyLiquidity(key, params, ZERO_BYTES);
 
         assertEq(manager.protocolFeesAccrued(currency0), 0);
@@ -810,8 +810,7 @@ contract PoolManagerTest is Test, Deployers {
         params.liquidityDelta = LIQUIDITY_PARAMS.liquidityDelta;
         modifyLiquidityRouter.modifyLiquidity(key, params, ZERO_BYTES);
 
-        PoolOperation.SwapParams memory swapParams =
-            PoolOperation.SwapParams(false, amountSpecified, TickMath.MAX_SQRT_PRICE - 1);
+        SwapParams memory swapParams = SwapParams(false, amountSpecified, TickMath.MAX_SQRT_PRICE - 1);
         BalanceDelta delta = swapRouter.swap(key, swapParams, PoolSwapTest.TestSettings(false, false), ZERO_BYTES);
         uint256 expectedProtocolFee =
             uint256(uint128(-delta.amount1())) * protocolFee1 / ProtocolFeeLibrary.PIPS_DENOMINATOR;
@@ -1052,10 +1051,7 @@ contract PoolManagerTest is Test, Deployers {
         assertEq(slot0ProtocolFee, MAX_PROTOCOL_FEE_BOTH_TOKENS);
 
         swapRouter.swap(
-            key,
-            PoolOperation.SwapParams(true, -10000, SQRT_PRICE_1_2),
-            PoolSwapTest.TestSettings(false, false),
-            ZERO_BYTES
+            key, SwapParams(true, -10000, SQRT_PRICE_1_2), PoolSwapTest.TestSettings(false, false), ZERO_BYTES
         );
 
         assertEq(manager.protocolFeesAccrued(currency0), expectedFees);
@@ -1081,10 +1077,7 @@ contract PoolManagerTest is Test, Deployers {
         assertEq(slot0ProtocolFee, MAX_PROTOCOL_FEE_BOTH_TOKENS);
 
         swapRouter.swap(
-            key,
-            PoolOperation.SwapParams(true, 10000, SQRT_PRICE_1_2),
-            PoolSwapTest.TestSettings(false, false),
-            ZERO_BYTES
+            key, SwapParams(true, 10000, SQRT_PRICE_1_2), PoolSwapTest.TestSettings(false, false), ZERO_BYTES
         );
 
         assertEq(manager.protocolFeesAccrued(currency0), expectedFees);
@@ -1110,7 +1103,7 @@ contract PoolManagerTest is Test, Deployers {
 
         swapRouter.swap(
             key,
-            PoolOperation.SwapParams(false, -10000, TickMath.MAX_SQRT_PRICE - 1),
+            SwapParams(false, -10000, TickMath.MAX_SQRT_PRICE - 1),
             PoolSwapTest.TestSettings(false, false),
             ZERO_BYTES
         );
@@ -1138,10 +1131,7 @@ contract PoolManagerTest is Test, Deployers {
         assertEq(slot0ProtocolFee, MAX_PROTOCOL_FEE_BOTH_TOKENS);
 
         swapRouter.swap{value: 10000}(
-            nativeKey,
-            PoolOperation.SwapParams(true, -10000, SQRT_PRICE_1_2),
-            PoolSwapTest.TestSettings(false, false),
-            ZERO_BYTES
+            nativeKey, SwapParams(true, -10000, SQRT_PRICE_1_2), PoolSwapTest.TestSettings(false, false), ZERO_BYTES
         );
 
         assertEq(manager.protocolFeesAccrued(nativeCurrency), expectedFees);
@@ -1168,10 +1158,7 @@ contract PoolManagerTest is Test, Deployers {
         assertEq(slot0ProtocolFee, MAX_PROTOCOL_FEE_BOTH_TOKENS);
 
         swapRouter.swap{value: 10000}(
-            nativeKey,
-            PoolOperation.SwapParams(true, -10000, SQRT_PRICE_1_2),
-            PoolSwapTest.TestSettings(false, false),
-            ZERO_BYTES
+            nativeKey, SwapParams(true, -10000, SQRT_PRICE_1_2), PoolSwapTest.TestSettings(false, false), ZERO_BYTES
         );
 
         assertEq(manager.protocolFeesAccrued(nativeCurrency), expectedFees);
@@ -1236,15 +1223,15 @@ contract PoolManagerTest is Test, Deployers {
     //     manager.initialize(key, SQRT_PRICE_1_1);
 
     //     // populate feeGrowthGlobalX128 struct w/ modify + swap
-    //     modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-120, 120, 5 ether, 0));
+    //     modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-120, 120, 5 ether, 0));
     //     swapRouter.swap(
     //         key,
-    //         PoolOperation.SwapParams(false, 1 ether, TickMath.MAX_SQRT_PRICE - 1),
+    //         SwapParams(false, 1 ether, TickMath.MAX_SQRT_PRICE - 1),
     //         PoolSwapTest.TestSettings(true, true)
     //     );
     //     swapRouter.swap(
     //         key,
-    //         PoolOperation.SwapParams(true, 5 ether, TickMath.MIN_SQRT_PRICE + 1),
+    //         SwapParams(true, 5 ether, TickMath.MIN_SQRT_PRICE + 1),
     //         PoolSwapTest.TestSettings(true, true)
     //     );
 

--- a/test/Sync.t.sol
+++ b/test/Sync.t.sol
@@ -11,7 +11,7 @@ import {IPoolManager} from "../src/interfaces/IPoolManager.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 import {IUnlockCallback} from "../src/interfaces/callback/IUnlockCallback.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
-import {PoolOperation} from "../src/types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "../src/types/PoolOperation.sol";
 import {ActionsRouter, Actions} from "../src/test/ActionsRouter.sol";
 import {SafeCast} from "../src/libraries/SafeCast.sol";
 import {CurrencyReserves} from "../src/libraries/CurrencyReserves.sol";
@@ -112,7 +112,7 @@ contract SyncTest is Test, Deployers {
 
         manager.initialize(key2, SQRT_PRICE_1_1);
 
-        modifyLiquidityRouter.modifyLiquidity(key2, PoolOperation.ModifyLiquidityParams(-60, 60, 100, 0), new bytes(0));
+        modifyLiquidityRouter.modifyLiquidity(key2, ModifyLiquidityParams(-60, 60, 100, 0), new bytes(0));
         (uint256 balanceCurrency2) = currency2.balanceOf(address(manager));
 
         Actions[] memory actions = new Actions[](2);

--- a/test/Sync.t.sol
+++ b/test/Sync.t.sol
@@ -11,6 +11,7 @@ import {IPoolManager} from "../src/interfaces/IPoolManager.sol";
 import {PoolSwapTest} from "../src/test/PoolSwapTest.sol";
 import {IUnlockCallback} from "../src/interfaces/callback/IUnlockCallback.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
+import {PoolOperation} from "../src/types/PoolOperation.sol";
 import {ActionsRouter, Actions} from "../src/test/ActionsRouter.sol";
 import {SafeCast} from "../src/libraries/SafeCast.sol";
 import {CurrencyReserves} from "../src/libraries/CurrencyReserves.sol";
@@ -111,7 +112,7 @@ contract SyncTest is Test, Deployers {
 
         manager.initialize(key2, SQRT_PRICE_1_1);
 
-        modifyLiquidityRouter.modifyLiquidity(key2, IPoolManager.ModifyLiquidityParams(-60, 60, 100, 0), new bytes(0));
+        modifyLiquidityRouter.modifyLiquidity(key2, PoolOperation.ModifyLiquidityParams(-60, 60, 100, 0), new bytes(0));
         (uint256 balanceCurrency2) = currency2.balanceOf(address(manager));
 
         Actions[] memory actions = new Actions[](2);

--- a/test/libraries/Hooks.t.sol
+++ b/test/libraries/Hooks.t.sol
@@ -17,6 +17,7 @@ import {Deployers} from "test/utils/Deployers.sol";
 import {ProtocolFees} from "../../src/ProtocolFees.sol";
 import {PoolId} from "../../src/types/PoolId.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
+import {PoolOperation} from "../../src/types/PoolOperation.sol";
 import {IERC20Minimal} from "../../src/interfaces/external/IERC20Minimal.sol";
 import {BalanceDelta} from "../../src/types/BalanceDelta.sol";
 import {BaseTestHooks} from "../../src/test/BaseTestHooks.sol";
@@ -66,11 +67,11 @@ contract HooksTest is Test, Deployers {
     function test_beforeAfterAddLiquidity_beforeAfterRemoveLiquidity_succeedsWithHook() public {
         MockERC20(Currency.unwrap(key.currency0)).mint(address(this), 1e18);
         MockERC20(Currency.unwrap(key.currency0)).approve(address(modifyLiquidityRouter), 1e18);
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
         assertEq(mockHooks.beforeAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterAddLiquidityData(), new bytes(111));
 
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(0, 60, -1e18, 0), new bytes(222));
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, -1e18, 0), new bytes(222));
         assertEq(mockHooks.beforeRemoveLiquidityData(), new bytes(222));
         assertEq(mockHooks.afterRemoveLiquidityData(), new bytes(222));
     }
@@ -78,7 +79,7 @@ contract HooksTest is Test, Deployers {
     function test_beforeAfterAddLiquidity_calledWithPositiveLiquidityDelta() public {
         MockERC20(Currency.unwrap(key.currency0)).mint(address(this), 1e18);
         MockERC20(Currency.unwrap(key.currency0)).approve(address(modifyLiquidityRouter), 1e18);
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(0, 60, 100, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 100, 0), new bytes(111));
         assertEq(mockHooks.beforeAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterAddLiquidityData(), new bytes(111));
     }
@@ -86,11 +87,11 @@ contract HooksTest is Test, Deployers {
     function test_beforeAfterRemoveLiquidity_calledWithZeroLiquidityDelta() public {
         MockERC20(Currency.unwrap(key.currency0)).mint(address(this), 1e18);
         MockERC20(Currency.unwrap(key.currency0)).approve(address(modifyLiquidityRouter), 1e18);
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
         assertEq(mockHooks.beforeAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterAddLiquidityData(), new bytes(111));
 
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(0, 60, 0, 0), new bytes(222));
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 0, 0), new bytes(222));
         assertEq(mockHooks.beforeAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.beforeRemoveLiquidityData(), new bytes(222));
@@ -98,10 +99,10 @@ contract HooksTest is Test, Deployers {
     }
 
     function test_beforeAfterRemoveLiquidity_calledWithPositiveLiquidityDelta() public {
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
         MockERC20(Currency.unwrap(key.currency0)).mint(address(this), 1e18);
         MockERC20(Currency.unwrap(key.currency0)).approve(address(modifyLiquidityRouter), 1e18);
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(0, 60, -1e18, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, -1e18, 0), new bytes(111));
         assertEq(mockHooks.beforeRemoveLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterRemoveLiquidityData(), new bytes(111));
     }
@@ -141,8 +142,8 @@ contract HooksTest is Test, Deployers {
     }
 
     function test_swap_succeedsWithHook() public {
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory swapParams =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
@@ -157,7 +158,7 @@ contract HooksTest is Test, Deployers {
         vm.expectRevert(Hooks.InvalidHookResponse.selector);
         swapRouter.swap(
             key,
-            IPoolManager.SwapParams(false, 100, SQRT_PRICE_1_1 + 60),
+            PoolOperation.SwapParams(false, 100, SQRT_PRICE_1_1 + 60),
             PoolSwapTest.TestSettings(true, true),
             ZERO_BYTES
         );
@@ -168,7 +169,7 @@ contract HooksTest is Test, Deployers {
         vm.expectRevert(Hooks.InvalidHookResponse.selector);
         swapRouter.swap(
             key,
-            IPoolManager.SwapParams(false, 100, SQRT_PRICE_1_1 + 60),
+            PoolOperation.SwapParams(false, 100, SQRT_PRICE_1_1 + 60),
             PoolSwapTest.TestSettings(true, true),
             ZERO_BYTES
         );
@@ -1003,8 +1004,8 @@ contract HooksTest is Test, Deployers {
         PoolKey memory key = PoolKey(currency0, currency1, 0, 60, IHooks(revertingHook));
         manager.initialize(key, SQRT_PRICE_1_1);
 
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory swapParams =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
@@ -1031,8 +1032,8 @@ contract HooksTest is Test, Deployers {
         PoolKey memory key = PoolKey(currency0, currency1, 0, 60, IHooks(address(revertingHook)));
         manager.initialize(key, SQRT_PRICE_1_1);
 
-        IPoolManager.SwapParams memory swapParams =
-            IPoolManager.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        PoolOperation.SwapParams memory swapParams =
+            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});

--- a/test/libraries/Hooks.t.sol
+++ b/test/libraries/Hooks.t.sol
@@ -17,7 +17,7 @@ import {Deployers} from "test/utils/Deployers.sol";
 import {ProtocolFees} from "../../src/ProtocolFees.sol";
 import {PoolId} from "../../src/types/PoolId.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
-import {PoolOperation} from "../../src/types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../../src/types/PoolOperation.sol";
 import {IERC20Minimal} from "../../src/interfaces/external/IERC20Minimal.sol";
 import {BalanceDelta} from "../../src/types/BalanceDelta.sol";
 import {BaseTestHooks} from "../../src/test/BaseTestHooks.sol";
@@ -67,11 +67,11 @@ contract HooksTest is Test, Deployers {
     function test_beforeAfterAddLiquidity_beforeAfterRemoveLiquidity_succeedsWithHook() public {
         MockERC20(Currency.unwrap(key.currency0)).mint(address(this), 1e18);
         MockERC20(Currency.unwrap(key.currency0)).approve(address(modifyLiquidityRouter), 1e18);
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
         assertEq(mockHooks.beforeAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterAddLiquidityData(), new bytes(111));
 
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, -1e18, 0), new bytes(222));
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(0, 60, -1e18, 0), new bytes(222));
         assertEq(mockHooks.beforeRemoveLiquidityData(), new bytes(222));
         assertEq(mockHooks.afterRemoveLiquidityData(), new bytes(222));
     }
@@ -79,7 +79,7 @@ contract HooksTest is Test, Deployers {
     function test_beforeAfterAddLiquidity_calledWithPositiveLiquidityDelta() public {
         MockERC20(Currency.unwrap(key.currency0)).mint(address(this), 1e18);
         MockERC20(Currency.unwrap(key.currency0)).approve(address(modifyLiquidityRouter), 1e18);
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 100, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(0, 60, 100, 0), new bytes(111));
         assertEq(mockHooks.beforeAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterAddLiquidityData(), new bytes(111));
     }
@@ -87,11 +87,11 @@ contract HooksTest is Test, Deployers {
     function test_beforeAfterRemoveLiquidity_calledWithZeroLiquidityDelta() public {
         MockERC20(Currency.unwrap(key.currency0)).mint(address(this), 1e18);
         MockERC20(Currency.unwrap(key.currency0)).approve(address(modifyLiquidityRouter), 1e18);
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
         assertEq(mockHooks.beforeAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterAddLiquidityData(), new bytes(111));
 
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 0, 0), new bytes(222));
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(0, 60, 0, 0), new bytes(222));
         assertEq(mockHooks.beforeAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterAddLiquidityData(), new bytes(111));
         assertEq(mockHooks.beforeRemoveLiquidityData(), new bytes(222));
@@ -99,10 +99,10 @@ contract HooksTest is Test, Deployers {
     }
 
     function test_beforeAfterRemoveLiquidity_calledWithPositiveLiquidityDelta() public {
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(0, 60, 1e18, 0), new bytes(111));
         MockERC20(Currency.unwrap(key.currency0)).mint(address(this), 1e18);
         MockERC20(Currency.unwrap(key.currency0)).approve(address(modifyLiquidityRouter), 1e18);
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(0, 60, -1e18, 0), new bytes(111));
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(0, 60, -1e18, 0), new bytes(111));
         assertEq(mockHooks.beforeRemoveLiquidityData(), new bytes(111));
         assertEq(mockHooks.afterRemoveLiquidityData(), new bytes(111));
     }
@@ -142,8 +142,8 @@ contract HooksTest is Test, Deployers {
     }
 
     function test_swap_succeedsWithHook() public {
-        PoolOperation.SwapParams memory swapParams =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory swapParams =
+            SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
@@ -157,10 +157,7 @@ contract HooksTest is Test, Deployers {
         mockHooks.setReturnValue(mockHooks.beforeSwap.selector, bytes4(0xdeadbeef));
         vm.expectRevert(Hooks.InvalidHookResponse.selector);
         swapRouter.swap(
-            key,
-            PoolOperation.SwapParams(false, 100, SQRT_PRICE_1_1 + 60),
-            PoolSwapTest.TestSettings(true, true),
-            ZERO_BYTES
+            key, SwapParams(false, 100, SQRT_PRICE_1_1 + 60), PoolSwapTest.TestSettings(true, true), ZERO_BYTES
         );
     }
 
@@ -168,10 +165,7 @@ contract HooksTest is Test, Deployers {
         mockHooks.setReturnValue(mockHooks.afterSwap.selector, bytes4(0xdeadbeef));
         vm.expectRevert(Hooks.InvalidHookResponse.selector);
         swapRouter.swap(
-            key,
-            PoolOperation.SwapParams(false, 100, SQRT_PRICE_1_1 + 60),
-            PoolSwapTest.TestSettings(true, true),
-            ZERO_BYTES
+            key, SwapParams(false, 100, SQRT_PRICE_1_1 + 60), PoolSwapTest.TestSettings(true, true), ZERO_BYTES
         );
     }
 
@@ -1004,8 +998,8 @@ contract HooksTest is Test, Deployers {
         PoolKey memory key = PoolKey(currency0, currency1, 0, 60, IHooks(revertingHook));
         manager.initialize(key, SQRT_PRICE_1_1);
 
-        PoolOperation.SwapParams memory swapParams =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory swapParams =
+            SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
@@ -1032,8 +1026,8 @@ contract HooksTest is Test, Deployers {
         PoolKey memory key = PoolKey(currency0, currency1, 0, 60, IHooks(address(revertingHook)));
         manager.initialize(key, SQRT_PRICE_1_1);
 
-        PoolOperation.SwapParams memory swapParams =
-            PoolOperation.SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+        SwapParams memory swapParams =
+            SwapParams({zeroForOne: true, amountSpecified: 100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
         PoolSwapTest.TestSettings memory testSettings =
             PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});

--- a/test/libraries/StateLibrary.t.sol
+++ b/test/libraries/StateLibrary.t.sol
@@ -6,6 +6,7 @@ import {IHooks} from "../../src/interfaces/IHooks.sol";
 import {Hooks} from "../../src/libraries/Hooks.sol";
 import {TickMath} from "../../src/libraries/TickMath.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
+import {PoolOperation} from "../../src/types/PoolOperation.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
 import {BalanceDelta} from "../../src/types/BalanceDelta.sol";
 import {PoolId} from "../../src/types/PoolId.sol";
@@ -38,11 +39,11 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     function test_getSlot0() public {
         // create liquidity
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
         );
 
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
         );
 
         // swap to create fees, crossing a tick
@@ -60,7 +61,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     }
 
     function test_getTickLiquidity() public {
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(-60, 60, 10 ether, 0), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-60, 60, 10 ether, 0), ZERO_BYTES);
 
         (uint128 liquidityGrossLower, int128 liquidityNetLower) = StateLibrary.getTickLiquidity(manager, poolId, -60);
         vm.snapshotGasLastCall("extsload getTickLiquidity");
@@ -72,8 +73,8 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(liquidityNetUpper, -10 ether);
     }
 
-    function test_fuzz_getTickLiquidity(IPoolManager.ModifyLiquidityParams memory params) public {
-        (IPoolManager.ModifyLiquidityParams memory _params,) =
+    function test_fuzz_getTickLiquidity(PoolOperation.ModifyLiquidityParams memory params) public {
+        (PoolOperation.ModifyLiquidityParams memory _params,) =
             Fuzzers.createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
         uint128 liquidityDelta = uint128(uint256(_params.liquidityDelta));
 
@@ -100,13 +101,13 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     }
 
     function test_fuzz_getTickLiquidity_two_positions(
-        IPoolManager.ModifyLiquidityParams memory paramsA,
-        IPoolManager.ModifyLiquidityParams memory paramsB
+        PoolOperation.ModifyLiquidityParams memory paramsA,
+        PoolOperation.ModifyLiquidityParams memory paramsB
     ) public {
-        (IPoolManager.ModifyLiquidityParams memory _paramsA,) = Fuzzers.createFuzzyLiquidityWithTightBound(
+        (PoolOperation.ModifyLiquidityParams memory _paramsA,) = Fuzzers.createFuzzyLiquidityWithTightBound(
             modifyLiquidityRouter, key, paramsA, SQRT_PRICE_1_1, ZERO_BYTES, 2
         );
-        (IPoolManager.ModifyLiquidityParams memory _paramsB,) = Fuzzers.createFuzzyLiquidityWithTightBound(
+        (PoolOperation.ModifyLiquidityParams memory _paramsB,) = Fuzzers.createFuzzyLiquidityWithTightBound(
             modifyLiquidityRouter, key, paramsB, SQRT_PRICE_1_1, ZERO_BYTES, 2
         );
 
@@ -170,7 +171,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         // create liquidity
         uint256 liquidity = 10_000 ether;
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-60, 60, int256(liquidity), 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-60, 60, int256(liquidity), 0), ZERO_BYTES
         );
 
         (uint256 feeGrowthGlobal0, uint256 feeGrowthGlobal1) = StateLibrary.getFeeGrowthGlobals(manager, poolId);
@@ -193,7 +194,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         // create liquidity
         uint256 liquidity = 10_000 ether;
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-60, 60, int256(liquidity), 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-60, 60, int256(liquidity), 0), ZERO_BYTES
         );
 
         (uint256 feeGrowthGlobal0, uint256 feeGrowthGlobal1) = StateLibrary.getFeeGrowthGlobals(manager, poolId);
@@ -212,9 +213,9 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     }
 
     function test_getLiquidity() public {
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(-60, 60, 10 ether, 0), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-60, 60, 10 ether, 0), ZERO_BYTES);
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-120, 120, 10 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-120, 120, 10 ether, 0), ZERO_BYTES
         );
 
         uint128 liquidity = StateLibrary.getLiquidity(manager, poolId);
@@ -222,8 +223,8 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(liquidity, 20 ether);
     }
 
-    function test_fuzz_getLiquidity(IPoolManager.ModifyLiquidityParams memory params) public {
-        (IPoolManager.ModifyLiquidityParams memory _params,) =
+    function test_fuzz_getLiquidity(PoolOperation.ModifyLiquidityParams memory params) public {
+        (PoolOperation.ModifyLiquidityParams memory _params,) =
             Fuzzers.createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
         (, int24 tick,,) = StateLibrary.getSlot0(manager, poolId);
         uint128 liquidity = StateLibrary.getLiquidity(manager, poolId);
@@ -241,7 +242,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         int24 tickUpper = 300;
         // create liquidity
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(tickLower, tickUpper, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(tickLower, tickUpper, 10_000 ether, 0), ZERO_BYTES
         );
 
         (int16 wordPos, uint8 bitPos) = TickBitmap.position(tickLower / key.tickSpacing);
@@ -256,8 +257,8 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(tickBitmap, 1 << bitPos);
     }
 
-    function test_fuzz_getTickBitmap(IPoolManager.ModifyLiquidityParams memory params) public {
-        (IPoolManager.ModifyLiquidityParams memory _params,) =
+    function test_fuzz_getTickBitmap(PoolOperation.ModifyLiquidityParams memory params) public {
+        (PoolOperation.ModifyLiquidityParams memory _params,) =
             Fuzzers.createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
 
         (int16 wordPos, uint8 bitPos) = TickBitmap.position(_params.tickLower / key.tickSpacing);
@@ -277,7 +278,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     function test_getPositionInfo() public {
         // create liquidity
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
         );
 
         // swap to create fees, crossing a tick
@@ -287,7 +288,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertNotEq(currentTick, -139);
 
         // poke the LP so that fees are updated
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
 
         bytes32 positionId =
             keccak256(abi.encodePacked(address(modifyLiquidityRouter), int24(-60), int24(60), bytes32(0)));
@@ -303,11 +304,11 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     }
 
     function test_fuzz_getPositionInfo(
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         uint256 swapAmount,
         bool zeroForOne
     ) public {
-        (IPoolManager.ModifyLiquidityParams memory _params, BalanceDelta delta) =
+        (PoolOperation.ModifyLiquidityParams memory _params, BalanceDelta delta) =
             createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
 
         uint256 delta0 = uint256(int256(-delta.amount0()));
@@ -323,7 +324,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
         // poke the LP so that fees are updated
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(_params.tickLower, _params.tickUpper, 0, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(_params.tickLower, _params.tickUpper, 0, 0), ZERO_BYTES
         );
 
         bytes32 positionId = keccak256(
@@ -346,11 +347,11 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     function test_getTickFeeGrowthOutside() public {
         // create liquidity
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
         );
 
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
         );
 
         // swap to create fees, crossing a tick
@@ -378,11 +379,11 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     function test_getTickInfo() public {
         // create liquidity
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
         );
 
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
         );
 
         // swap to create fees, crossing a tick
@@ -413,11 +414,11 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     function test_getFeeGrowthInside() public {
         // create liquidity
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
         );
 
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
         );
 
         // swap to create fees, crossing a tick
@@ -432,7 +433,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         vm.snapshotGasLastCall("extsload getFeeGrowthInside");
 
         // poke the LP so that fees are updated
-        modifyLiquidityRouter.modifyLiquidity(key, IPoolManager.ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
 
         bytes32 positionId =
             keccak256(abi.encodePacked(address(modifyLiquidityRouter), int24(-60), int24(60), bytes32(0)));
@@ -445,16 +446,16 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(feeGrowthInside1X128, feeGrowthInside1X128_);
     }
 
-    function test_fuzz_getFeeGrowthInside(IPoolManager.ModifyLiquidityParams memory params, bool zeroForOne) public {
+    function test_fuzz_getFeeGrowthInside(PoolOperation.ModifyLiquidityParams memory params, bool zeroForOne) public {
         modifyLiquidityRouter.modifyLiquidity(
             key,
-            IPoolManager.ModifyLiquidityParams(
+            PoolOperation.ModifyLiquidityParams(
                 TickMath.minUsableTick(key.tickSpacing), TickMath.maxUsableTick(key.tickSpacing), 10_000 ether, 0
             ),
             ZERO_BYTES
         );
 
-        (IPoolManager.ModifyLiquidityParams memory _params,) =
+        (PoolOperation.ModifyLiquidityParams memory _params,) =
             createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
 
         swap(key, zeroForOne, -int256(100e18), ZERO_BYTES);
@@ -465,7 +466,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
         // poke the LP so that fees are updated
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(_params.tickLower, _params.tickUpper, 0, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(_params.tickLower, _params.tickUpper, 0, 0), ZERO_BYTES
         );
         bytes32 positionId = keccak256(
             abi.encodePacked(address(modifyLiquidityRouter), _params.tickLower, _params.tickUpper, bytes32(0))
@@ -481,7 +482,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     function test_getPositionLiquidity() public {
         // create liquidity
         modifyLiquidityRouter.modifyLiquidity(
-            key, IPoolManager.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
+            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
         );
 
         bytes32 positionId =
@@ -494,13 +495,13 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     }
 
     function test_fuzz_getPositionLiquidity(
-        IPoolManager.ModifyLiquidityParams memory paramsA,
-        IPoolManager.ModifyLiquidityParams memory paramsB
+        PoolOperation.ModifyLiquidityParams memory paramsA,
+        PoolOperation.ModifyLiquidityParams memory paramsB
     ) public {
-        (IPoolManager.ModifyLiquidityParams memory _paramsA) =
+        (PoolOperation.ModifyLiquidityParams memory _paramsA) =
             Fuzzers.createFuzzyLiquidityParams(key, paramsA, SQRT_PRICE_1_1);
 
-        (IPoolManager.ModifyLiquidityParams memory _paramsB) =
+        (PoolOperation.ModifyLiquidityParams memory _paramsB) =
             Fuzzers.createFuzzyLiquidityParams(key, paramsB, SQRT_PRICE_1_1);
 
         // Assume there are no overlapping positions

--- a/test/libraries/StateLibrary.t.sol
+++ b/test/libraries/StateLibrary.t.sol
@@ -6,7 +6,7 @@ import {IHooks} from "../../src/interfaces/IHooks.sol";
 import {Hooks} from "../../src/libraries/Hooks.sol";
 import {TickMath} from "../../src/libraries/TickMath.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
-import {PoolOperation} from "../../src/types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "../../src/types/PoolOperation.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
 import {BalanceDelta} from "../../src/types/BalanceDelta.sol";
 import {PoolId} from "../../src/types/PoolId.sol";
@@ -38,13 +38,9 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
     function test_getSlot0() public {
         // create liquidity
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES);
 
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES);
 
         // swap to create fees, crossing a tick
         uint256 swapAmount = 100 ether;
@@ -61,7 +57,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     }
 
     function test_getTickLiquidity() public {
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-60, 60, 10 ether, 0), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10 ether, 0), ZERO_BYTES);
 
         (uint128 liquidityGrossLower, int128 liquidityNetLower) = StateLibrary.getTickLiquidity(manager, poolId, -60);
         vm.snapshotGasLastCall("extsload getTickLiquidity");
@@ -73,8 +69,8 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(liquidityNetUpper, -10 ether);
     }
 
-    function test_fuzz_getTickLiquidity(PoolOperation.ModifyLiquidityParams memory params) public {
-        (PoolOperation.ModifyLiquidityParams memory _params,) =
+    function test_fuzz_getTickLiquidity(ModifyLiquidityParams memory params) public {
+        (ModifyLiquidityParams memory _params,) =
             Fuzzers.createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
         uint128 liquidityDelta = uint128(uint256(_params.liquidityDelta));
 
@@ -101,13 +97,13 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     }
 
     function test_fuzz_getTickLiquidity_two_positions(
-        PoolOperation.ModifyLiquidityParams memory paramsA,
-        PoolOperation.ModifyLiquidityParams memory paramsB
+        ModifyLiquidityParams memory paramsA,
+        ModifyLiquidityParams memory paramsB
     ) public {
-        (PoolOperation.ModifyLiquidityParams memory _paramsA,) = Fuzzers.createFuzzyLiquidityWithTightBound(
+        (ModifyLiquidityParams memory _paramsA,) = Fuzzers.createFuzzyLiquidityWithTightBound(
             modifyLiquidityRouter, key, paramsA, SQRT_PRICE_1_1, ZERO_BYTES, 2
         );
-        (PoolOperation.ModifyLiquidityParams memory _paramsB,) = Fuzzers.createFuzzyLiquidityWithTightBound(
+        (ModifyLiquidityParams memory _paramsB,) = Fuzzers.createFuzzyLiquidityWithTightBound(
             modifyLiquidityRouter, key, paramsB, SQRT_PRICE_1_1, ZERO_BYTES, 2
         );
 
@@ -170,9 +166,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     function test_getFeeGrowthGlobals0() public {
         // create liquidity
         uint256 liquidity = 10_000 ether;
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-60, 60, int256(liquidity), 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, int256(liquidity), 0), ZERO_BYTES);
 
         (uint256 feeGrowthGlobal0, uint256 feeGrowthGlobal1) = StateLibrary.getFeeGrowthGlobals(manager, poolId);
         assertEq(feeGrowthGlobal0, 0);
@@ -193,9 +187,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     function test_getFeeGrowthGlobals1() public {
         // create liquidity
         uint256 liquidity = 10_000 ether;
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-60, 60, int256(liquidity), 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, int256(liquidity), 0), ZERO_BYTES);
 
         (uint256 feeGrowthGlobal0, uint256 feeGrowthGlobal1) = StateLibrary.getFeeGrowthGlobals(manager, poolId);
         assertEq(feeGrowthGlobal0, 0);
@@ -213,18 +205,16 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     }
 
     function test_getLiquidity() public {
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-60, 60, 10 ether, 0), ZERO_BYTES);
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-120, 120, 10 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10 ether, 0), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-120, 120, 10 ether, 0), ZERO_BYTES);
 
         uint128 liquidity = StateLibrary.getLiquidity(manager, poolId);
         vm.snapshotGasLastCall("extsload getLiquidity");
         assertEq(liquidity, 20 ether);
     }
 
-    function test_fuzz_getLiquidity(PoolOperation.ModifyLiquidityParams memory params) public {
-        (PoolOperation.ModifyLiquidityParams memory _params,) =
+    function test_fuzz_getLiquidity(ModifyLiquidityParams memory params) public {
+        (ModifyLiquidityParams memory _params,) =
             Fuzzers.createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
         (, int24 tick,,) = StateLibrary.getSlot0(manager, poolId);
         uint128 liquidity = StateLibrary.getLiquidity(manager, poolId);
@@ -242,7 +232,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         int24 tickUpper = 300;
         // create liquidity
         modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(tickLower, tickUpper, 10_000 ether, 0), ZERO_BYTES
+            key, ModifyLiquidityParams(tickLower, tickUpper, 10_000 ether, 0), ZERO_BYTES
         );
 
         (int16 wordPos, uint8 bitPos) = TickBitmap.position(tickLower / key.tickSpacing);
@@ -257,8 +247,8 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(tickBitmap, 1 << bitPos);
     }
 
-    function test_fuzz_getTickBitmap(PoolOperation.ModifyLiquidityParams memory params) public {
-        (PoolOperation.ModifyLiquidityParams memory _params,) =
+    function test_fuzz_getTickBitmap(ModifyLiquidityParams memory params) public {
+        (ModifyLiquidityParams memory _params,) =
             Fuzzers.createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
 
         (int16 wordPos, uint8 bitPos) = TickBitmap.position(_params.tickLower / key.tickSpacing);
@@ -277,9 +267,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
     function test_getPositionInfo() public {
         // create liquidity
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES);
 
         // swap to create fees, crossing a tick
         uint256 swapAmount = 10 ether;
@@ -288,7 +276,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertNotEq(currentTick, -139);
 
         // poke the LP so that fees are updated
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
 
         bytes32 positionId =
             keccak256(abi.encodePacked(address(modifyLiquidityRouter), int24(-60), int24(60), bytes32(0)));
@@ -303,12 +291,10 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(feeGrowthInside1X128, 0);
     }
 
-    function test_fuzz_getPositionInfo(
-        PoolOperation.ModifyLiquidityParams memory params,
-        uint256 swapAmount,
-        bool zeroForOne
-    ) public {
-        (PoolOperation.ModifyLiquidityParams memory _params, BalanceDelta delta) =
+    function test_fuzz_getPositionInfo(ModifyLiquidityParams memory params, uint256 swapAmount, bool zeroForOne)
+        public
+    {
+        (ModifyLiquidityParams memory _params, BalanceDelta delta) =
             createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
 
         uint256 delta0 = uint256(int256(-delta.amount0()));
@@ -324,7 +310,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
         // poke the LP so that fees are updated
         modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(_params.tickLower, _params.tickUpper, 0, 0), ZERO_BYTES
+            key, ModifyLiquidityParams(_params.tickLower, _params.tickUpper, 0, 0), ZERO_BYTES
         );
 
         bytes32 positionId = keccak256(
@@ -346,13 +332,9 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
     function test_getTickFeeGrowthOutside() public {
         // create liquidity
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES);
 
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES);
 
         // swap to create fees, crossing a tick
         uint256 swapAmount = 100 ether;
@@ -378,13 +360,9 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
     // also hard to fuzz because of feeGrowthOutside
     function test_getTickInfo() public {
         // create liquidity
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES);
 
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES);
 
         // swap to create fees, crossing a tick
         uint256 swapAmount = 100 ether;
@@ -413,13 +391,9 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
     function test_getFeeGrowthInside() public {
         // create liquidity
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES);
 
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-600, 600, 10_000 ether, 0), ZERO_BYTES);
 
         // swap to create fees, crossing a tick
         uint256 swapAmount = 100 ether;
@@ -433,7 +407,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         vm.snapshotGasLastCall("extsload getFeeGrowthInside");
 
         // poke the LP so that fees are updated
-        modifyLiquidityRouter.modifyLiquidity(key, PoolOperation.ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 0, 0), ZERO_BYTES);
 
         bytes32 positionId =
             keccak256(abi.encodePacked(address(modifyLiquidityRouter), int24(-60), int24(60), bytes32(0)));
@@ -446,16 +420,16 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(feeGrowthInside1X128, feeGrowthInside1X128_);
     }
 
-    function test_fuzz_getFeeGrowthInside(PoolOperation.ModifyLiquidityParams memory params, bool zeroForOne) public {
+    function test_fuzz_getFeeGrowthInside(ModifyLiquidityParams memory params, bool zeroForOne) public {
         modifyLiquidityRouter.modifyLiquidity(
             key,
-            PoolOperation.ModifyLiquidityParams(
+            ModifyLiquidityParams(
                 TickMath.minUsableTick(key.tickSpacing), TickMath.maxUsableTick(key.tickSpacing), 10_000 ether, 0
             ),
             ZERO_BYTES
         );
 
-        (PoolOperation.ModifyLiquidityParams memory _params,) =
+        (ModifyLiquidityParams memory _params,) =
             createFuzzyLiquidity(modifyLiquidityRouter, key, params, SQRT_PRICE_1_1, ZERO_BYTES);
 
         swap(key, zeroForOne, -int256(100e18), ZERO_BYTES);
@@ -466,7 +440,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
         // poke the LP so that fees are updated
         modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(_params.tickLower, _params.tickUpper, 0, 0), ZERO_BYTES
+            key, ModifyLiquidityParams(_params.tickLower, _params.tickUpper, 0, 0), ZERO_BYTES
         );
         bytes32 positionId = keccak256(
             abi.encodePacked(address(modifyLiquidityRouter), _params.tickLower, _params.tickUpper, bytes32(0))
@@ -481,9 +455,7 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
 
     function test_getPositionLiquidity() public {
         // create liquidity
-        modifyLiquidityRouter.modifyLiquidity(
-            key, PoolOperation.ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES
-        );
+        modifyLiquidityRouter.modifyLiquidity(key, ModifyLiquidityParams(-60, 60, 10_000 ether, 0), ZERO_BYTES);
 
         bytes32 positionId =
             keccak256(abi.encodePacked(address(modifyLiquidityRouter), int24(-60), int24(60), bytes32(0)));
@@ -494,15 +466,12 @@ contract StateLibraryTest is Test, Deployers, Fuzzers {
         assertEq(liquidity, 10_000 ether);
     }
 
-    function test_fuzz_getPositionLiquidity(
-        PoolOperation.ModifyLiquidityParams memory paramsA,
-        PoolOperation.ModifyLiquidityParams memory paramsB
-    ) public {
-        (PoolOperation.ModifyLiquidityParams memory _paramsA) =
-            Fuzzers.createFuzzyLiquidityParams(key, paramsA, SQRT_PRICE_1_1);
+    function test_fuzz_getPositionLiquidity(ModifyLiquidityParams memory paramsA, ModifyLiquidityParams memory paramsB)
+        public
+    {
+        (ModifyLiquidityParams memory _paramsA) = Fuzzers.createFuzzyLiquidityParams(key, paramsA, SQRT_PRICE_1_1);
 
-        (PoolOperation.ModifyLiquidityParams memory _paramsB) =
-            Fuzzers.createFuzzyLiquidityParams(key, paramsB, SQRT_PRICE_1_1);
+        (ModifyLiquidityParams memory _paramsB) = Fuzzers.createFuzzyLiquidityParams(key, paramsB, SQRT_PRICE_1_1);
 
         // Assume there are no overlapping positions
         vm.assume(

--- a/test/utils/AmountHelpers.sol
+++ b/test/utils/AmountHelpers.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import {LiquidityAmounts} from "./LiquidityAmounts.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
+import {PoolOperation} from "../../src/types/PoolOperation.sol";
 import {PoolId} from "../../src/types/PoolId.sol";
 import {TickMath} from "../../src/libraries/TickMath.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
@@ -13,7 +14,7 @@ import {StateLibrary} from "../../src/libraries/StateLibrary.sol";
 library AmountHelpers {
     function getMaxAmountInForPool(
         IPoolManager manager,
-        IPoolManager.ModifyLiquidityParams memory params,
+        PoolOperation.ModifyLiquidityParams memory params,
         PoolKey memory key
     ) public view returns (uint256 amount0, uint256 amount1) {
         PoolId id = key.toId();

--- a/test/utils/AmountHelpers.sol
+++ b/test/utils/AmountHelpers.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {LiquidityAmounts} from "./LiquidityAmounts.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
-import {PoolOperation} from "../../src/types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "../../src/types/PoolOperation.sol";
 import {PoolId} from "../../src/types/PoolId.sol";
 import {TickMath} from "../../src/libraries/TickMath.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
@@ -12,11 +12,11 @@ import {StateLibrary} from "../../src/libraries/StateLibrary.sol";
 /// @title Calculate token<>liquidity
 /// @notice Helps calculate amounts for bounding fuzz tests
 library AmountHelpers {
-    function getMaxAmountInForPool(
-        IPoolManager manager,
-        PoolOperation.ModifyLiquidityParams memory params,
-        PoolKey memory key
-    ) public view returns (uint256 amount0, uint256 amount1) {
+    function getMaxAmountInForPool(IPoolManager manager, ModifyLiquidityParams memory params, PoolKey memory key)
+        public
+        view
+        returns (uint256 amount0, uint256 amount1)
+    {
         PoolId id = key.toId();
         uint128 liquidity = StateLibrary.getLiquidity(manager, id);
         (uint160 sqrtPriceX96,,,) = StateLibrary.getSlot0(manager, id);

--- a/test/utils/Deployers.sol
+++ b/test/utils/Deployers.sol
@@ -8,6 +8,7 @@ import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";
 import {IHooks} from "../../src/interfaces/IHooks.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
 import {PoolManager} from "../../src/PoolManager.sol";
+import {PoolOperation} from "../../src/types/PoolOperation.sol";
 import {PoolId} from "../../src/types/PoolId.sol";
 import {LPFeeLibrary} from "../../src/libraries/LPFeeLibrary.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
@@ -42,12 +43,12 @@ contract Deployers is Test {
     uint160 public constant MIN_PRICE_LIMIT = TickMath.MIN_SQRT_PRICE + 1;
     uint160 public constant MAX_PRICE_LIMIT = TickMath.MAX_SQRT_PRICE - 1;
 
-    IPoolManager.ModifyLiquidityParams public LIQUIDITY_PARAMS =
-        IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
-    IPoolManager.ModifyLiquidityParams public REMOVE_LIQUIDITY_PARAMS =
-        IPoolManager.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
-    IPoolManager.SwapParams public SWAP_PARAMS =
-        IPoolManager.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+    PoolOperation.ModifyLiquidityParams public LIQUIDITY_PARAMS =
+        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
+    PoolOperation.ModifyLiquidityParams public REMOVE_LIQUIDITY_PARAMS =
+        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
+    PoolOperation.SwapParams public SWAP_PARAMS =
+        PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
     // Global variables
     Currency internal currency0;
@@ -222,7 +223,7 @@ contract Deployers is Test {
 
         return swapRouter.swap{value: value}(
             _key,
-            IPoolManager.SwapParams({
+            PoolOperation.SwapParams({
                 zeroForOne: zeroForOne,
                 amountSpecified: amountSpecified,
                 sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT
@@ -244,7 +245,7 @@ contract Deployers is Test {
             amount1
         );
 
-        IPoolManager.ModifyLiquidityParams memory params = IPoolManager.ModifyLiquidityParams({
+        PoolOperation.ModifyLiquidityParams memory params = PoolOperation.ModifyLiquidityParams({
             tickLower: LIQUIDITY_PARAMS.tickLower,
             tickUpper: LIQUIDITY_PARAMS.tickUpper,
             liquidityDelta: int128(liquidityDelta),
@@ -267,7 +268,7 @@ contract Deployers is Test {
 
         return swapRouter.swap{value: msgValue}(
             _key,
-            IPoolManager.SwapParams({
+            PoolOperation.SwapParams({
                 zeroForOne: zeroForOne,
                 amountSpecified: amountSpecified,
                 sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT

--- a/test/utils/Deployers.sol
+++ b/test/utils/Deployers.sol
@@ -8,7 +8,7 @@ import {Currency, CurrencyLibrary} from "../../src/types/Currency.sol";
 import {IHooks} from "../../src/interfaces/IHooks.sol";
 import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
 import {PoolManager} from "../../src/PoolManager.sol";
-import {PoolOperation} from "../../src/types/PoolOperation.sol";
+import {ModifyLiquidityParams, SwapParams} from "../../src/types/PoolOperation.sol";
 import {PoolId} from "../../src/types/PoolId.sol";
 import {LPFeeLibrary} from "../../src/libraries/LPFeeLibrary.sol";
 import {PoolKey} from "../../src/types/PoolKey.sol";
@@ -43,12 +43,12 @@ contract Deployers is Test {
     uint160 public constant MIN_PRICE_LIMIT = TickMath.MIN_SQRT_PRICE + 1;
     uint160 public constant MAX_PRICE_LIMIT = TickMath.MAX_SQRT_PRICE - 1;
 
-    PoolOperation.ModifyLiquidityParams public LIQUIDITY_PARAMS =
-        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
-    PoolOperation.ModifyLiquidityParams public REMOVE_LIQUIDITY_PARAMS =
-        PoolOperation.ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
-    PoolOperation.SwapParams public SWAP_PARAMS =
-        PoolOperation.SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
+    ModifyLiquidityParams public LIQUIDITY_PARAMS =
+        ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: 1e18, salt: 0});
+    ModifyLiquidityParams public REMOVE_LIQUIDITY_PARAMS =
+        ModifyLiquidityParams({tickLower: -120, tickUpper: 120, liquidityDelta: -1e18, salt: 0});
+    SwapParams public SWAP_PARAMS =
+        SwapParams({zeroForOne: true, amountSpecified: -100, sqrtPriceLimitX96: SQRT_PRICE_1_2});
 
     // Global variables
     Currency internal currency0;
@@ -223,7 +223,7 @@ contract Deployers is Test {
 
         return swapRouter.swap{value: value}(
             _key,
-            PoolOperation.SwapParams({
+            SwapParams({
                 zeroForOne: zeroForOne,
                 amountSpecified: amountSpecified,
                 sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT
@@ -245,7 +245,7 @@ contract Deployers is Test {
             amount1
         );
 
-        PoolOperation.ModifyLiquidityParams memory params = PoolOperation.ModifyLiquidityParams({
+        ModifyLiquidityParams memory params = ModifyLiquidityParams({
             tickLower: LIQUIDITY_PARAMS.tickLower,
             tickUpper: LIQUIDITY_PARAMS.tickUpper,
             liquidityDelta: int128(liquidityDelta),
@@ -268,7 +268,7 @@ contract Deployers is Test {
 
         return swapRouter.swap{value: msgValue}(
             _key,
-            PoolOperation.SwapParams({
+            SwapParams({
                 zeroForOne: zeroForOne,
                 amountSpecified: amountSpecified,
                 sqrtPriceLimitX96: zeroForOne ? MIN_PRICE_LIMIT : MAX_PRICE_LIMIT

--- a/test/utils/Logger.sol
+++ b/test/utils/Logger.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
-import {IPoolManager} from "../../src/interfaces/IPoolManager.sol";
+import {PoolOperation} from "../../src/types/PoolOperation.sol";
 
 import "forge-std/console2.sol";
 
 // Useful for printing out the true values in a fuzz. For failing fuzzes, foundry logs the unsanitized params.
 contract Logger {
-    function logParams(IPoolManager.ModifyLiquidityParams memory params) public pure {
+    function logParams(PoolOperation.ModifyLiquidityParams memory params) public pure {
         console2.log("ModifyLiquidity.tickLower", params.tickLower);
         console2.log("ModifyLiquidity.tickUpper", params.tickUpper);
         console2.log("ModifyLiquidity.liquidityDelta", params.liquidityDelta);

--- a/test/utils/Logger.sol
+++ b/test/utils/Logger.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
-import {PoolOperation} from "../../src/types/PoolOperation.sol";
+import {ModifyLiquidityParams} from "../../src/types/PoolOperation.sol";
 
 import "forge-std/console2.sol";
 
 // Useful for printing out the true values in a fuzz. For failing fuzzes, foundry logs the unsanitized params.
 contract Logger {
-    function logParams(PoolOperation.ModifyLiquidityParams memory params) public pure {
+    function logParams(ModifyLiquidityParams memory params) public pure {
         console2.log("ModifyLiquidity.tickLower", params.tickLower);
         console2.log("ModifyLiquidity.tickUpper", params.tickUpper);
         console2.log("ModifyLiquidity.liquidityDelta", params.liquidityDelta);


### PR DESCRIPTION
## Related Issue

This resolves an issue that causes builds to fail in certain conditions.

## Description of changes

- Created `types/PoolOperation.sol` consisting of the structs `ModifyLiquidityParams` and `SwapParams` which are removed from `interfaces/IPoolManager.sol`
- Updated references to point to the new location of these structs.