### PR TITLE
linting(solhint): removing unused solhint file

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,6 +1,0 @@
-{
-  "plugins": ["prettier"],
-  "rules": {
-    "prettier/prettier": "error"
-  }
-}


### PR DESCRIPTION
## Related Issue

Which issue does this pull request resolve: #975 

## Description of changes
Deleted `.solhint.json` since it's not being used. The `Run linters` workflow should confirm this if it runs successfully.
