### PR TITLE
docs: improve NatSpec and clarify internal comments

### DIFF
--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -114,6 +114,8 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
+    /// @dev Events are emitted before the afterInitialize hook to ensure event ordering.
+    /// @dev This function initializes the pool state and parameters.
     function initialize(PoolKey memory key, uint160 sqrtPriceX96) external noDelegateCall returns (int24 tick) {
         // see TickBitmap.sol for overflow conditions that can arise from tick spacing being too large
         if (key.tickSpacing > MAX_TICK_SPACING) TickSpacingTooLarge.selector.revertWith(key.tickSpacing);
@@ -142,6 +144,8 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
+    /// @dev Events are emitted before the afterModifyLiquidity hook to ensure event ordering.
+    /// @dev Reverts if the pool is locked.
     function modifyLiquidity(PoolKey memory key, ModifyLiquidityParams memory params, bytes calldata hookData)
         external
         onlyWhenUnlocked
@@ -184,6 +188,8 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
+    /// @dev Events are emitted before the afterSwap hook to ensure event ordering.
+    /// @dev Reverts if the pool is locked.
     function swap(PoolKey memory key, SwapParams memory params, bytes calldata hookData)
         external
         onlyWhenUnlocked
@@ -253,6 +259,8 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
+    /// @dev Events are emitted before the afterDonate hook to ensure event ordering.
+    /// @dev Reverts if the pool is locked.
     function donate(PoolKey memory key, uint256 amount0, uint256 amount1, bytes calldata hookData)
         external
         onlyWhenUnlocked

--- a/src/libraries/CurrencyReserves.sol
+++ b/src/libraries/CurrencyReserves.sol
@@ -7,9 +7,11 @@ import {CustomRevert} from "./CustomRevert.sol";
 library CurrencyReserves {
     using CustomRevert for bytes4;
 
-    /// bytes32(uint256(keccak256("ReservesOf")) - 1)
+    /// @dev The slot holding the reserves of the synced currency.
+    /// Calculated as `bytes32(uint256(keccak256("ReservesOf")) - 1)` to effectively namespace the slot and avoid collisions.
     bytes32 constant RESERVES_OF_SLOT = 0x1e0745a7db1623981f0b2a5d4232364c00787266eb75ad546f190e6cebe9bd95;
-    /// bytes32(uint256(keccak256("Currency")) - 1)
+    /// @dev The slot holding the currently synced currency.
+    /// Calculated as `bytes32(uint256(keccak256("Currency")) - 1)` to effectively namespace the slot and avoid collisions.
     bytes32 constant CURRENCY_SLOT = 0x27e098c505d44ec3574004bca052aabf76bd35004c182099d8c575fb238593b9;
 
     function getSyncedCurrency() internal view returns (Currency currency) {

--- a/src/libraries/Lock.sol
+++ b/src/libraries/Lock.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.24;
 
 /// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
-/// TODO: This library can be deleted when we have the transient keyword support in solidity.
+/// @dev TODO: This library can be deleted when the `transient` keyword is fully supported and stabilized in Solidity.
+/// Currently, assembly is used to access the `tstore` and `tload` opcodes directly for gas efficiency and availability.
 library Lock {
     // The slot holding the unlocked state, transiently. bytes32(uint256(keccak256("Unlocked")) - 1)
     bytes32 internal constant IS_UNLOCKED_SLOT = 0xc090fc4683624cfc3884e9d8de5eca132f2d0ec062aff75d43c0465d5ceeab23;

--- a/src/libraries/NonzeroDeltaCount.sol
+++ b/src/libraries/NonzeroDeltaCount.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.24;
 
 /// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
 /// for the nonzero delta count.
-/// TODO: This library can be deleted when we have the transient keyword support in solidity.
+/// @dev TODO: This library can be deleted when the `transient` keyword is fully supported and stabilized in Solidity.
+/// Currently, assembly is used to access the `tstore` and `tload` opcodes directly for gas efficiency and availability.
 library NonzeroDeltaCount {
     // The slot holding the number of nonzero deltas. bytes32(uint256(keccak256("NonzeroDeltaCount")) - 1)
     bytes32 internal constant NONZERO_DELTA_COUNT_SLOT =


### PR DESCRIPTION
## Related Issue
N/A
## Description of changes
This PR improves documentation across several core files to enhance readability and maintainability.
- **PoolManager.sol**: Added `@dev` notes to external functions to clarify event emission ordering and lock checks.
- **Lock.sol / NonzeroDeltaCount.sol**: Expanded comments on ephemeral storage to explain current assembly usage vs future `transient` keyword support.
- **CurrencyReserves.sol**: Documented storage slot derivation for better clarity.