### PR TITLE
docs: Add comprehensive NatSpec documentation to core libraries and types

### DIFF
--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -114,6 +114,8 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
+    /// @dev Events are emitted before the afterInitialize hook to ensure event ordering.
+    /// @dev This function initializes the pool state and parameters.
     function initialize(PoolKey memory key, uint160 sqrtPriceX96) external noDelegateCall returns (int24 tick) {
         // see TickBitmap.sol for overflow conditions that can arise from tick spacing being too large
         if (key.tickSpacing > MAX_TICK_SPACING) TickSpacingTooLarge.selector.revertWith(key.tickSpacing);
@@ -142,6 +144,8 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
+    /// @dev Events are emitted before the afterModifyLiquidity hook to ensure event ordering.
+    /// @dev Reverts if the pool is locked.
     function modifyLiquidity(PoolKey memory key, ModifyLiquidityParams memory params, bytes calldata hookData)
         external
         onlyWhenUnlocked
@@ -184,6 +188,8 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
+    /// @dev Events are emitted before the afterSwap hook to ensure event ordering.
+    /// @dev Reverts if the pool is locked.
     function swap(PoolKey memory key, SwapParams memory params, bytes calldata hookData)
         external
         onlyWhenUnlocked
@@ -253,6 +259,8 @@ contract PoolManager is IPoolManager, ProtocolFees, NoDelegateCall, ERC6909Claim
     }
 
     /// @inheritdoc IPoolManager
+    /// @dev Events are emitted before the afterDonate hook to ensure event ordering.
+    /// @dev Reverts if the pool is locked.
     function donate(PoolKey memory key, uint256 amount0, uint256 amount1, bytes calldata hookData)
         external
         onlyWhenUnlocked

--- a/src/libraries/BitMath.sol
+++ b/src/libraries/BitMath.sol
@@ -2,22 +2,37 @@
 pragma solidity ^0.8.0;
 
 /// @title BitMath
-/// @dev This library provides functionality for computing bit properties of an unsigned integer
+/// @notice This library provides functionality for computing bit properties of an unsigned integer
+/// @dev Provides gas-efficient methods for finding the most and least significant bits in a uint256.
+/// These operations are fundamental for tick bitmap navigation in Uniswap v4's concentrated liquidity.
+/// Both functions use optimized algorithms with De Bruijn sequences for O(1) bit manipulation.
 /// @author Solady (https://github.com/Vectorized/solady/blob/8200a70e8dc2a77ecb074fc2e99a2a0d36547522/src/utils/LibBit.sol)
 library BitMath {
     /// @notice Returns the index of the most significant bit of the number,
     ///     where the least significant bit is at index 0 and the most significant bit is at index 255
+    /// @dev Uses a binary search approach combined with De Bruijn sequences for efficiency.
+    /// The algorithm first narrows down which 128/64/32/16/8-bit section contains the MSB,
+    /// then uses a De Bruijn lookup for the final precision.
     /// @param x the value for which to compute the most significant bit, must be greater than 0
-    /// @return r the index of the most significant bit
+    /// @return r the index of the most significant bit (0-255)
     function mostSignificantBit(uint256 x) internal pure returns (uint8 r) {
         require(x > 0);
 
         assembly ("memory-safe") {
+            // Binary search: check if MSB is in upper half of remaining bits
+            // lt(0xFFFF..., x) returns 1 if x > threshold, meaning MSB is in upper half
+            // shl(7, ...) sets bit 7 (value 128) if MSB is in upper 128 bits
             r := shl(7, lt(0xffffffffffffffffffffffffffffffff, x))
+            // Check upper 64 bits of remaining section
             r := or(r, shl(6, lt(0xffffffffffffffff, shr(r, x))))
+            // Check upper 32 bits of remaining section
             r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+            // Check upper 16 bits of remaining section
             r := or(r, shl(4, lt(0xffff, shr(r, x))))
+            // Check upper 8 bits of remaining section
             r := or(r, shl(3, lt(0xff, shr(r, x))))
+            // Final 8-bit precision: use De Bruijn-like lookup table for remaining bits
+            // The magic numbers encode a compact lookup that maps bit patterns to bit indices
             // forgefmt: disable-next-item
             r := or(r, byte(and(0x1f, shr(shr(r, x), 0x8421084210842108cc6318c6db6d54be)),
                 0x0706060506020500060203020504000106050205030304010505030400000000))
@@ -26,21 +41,29 @@ library BitMath {
 
     /// @notice Returns the index of the least significant bit of the number,
     ///     where the least significant bit is at index 0 and the most significant bit is at index 255
+    /// @dev First isolates the LSB using two's complement (x & -x), then uses De Bruijn multiplication
+    /// to efficiently compute the bit index. This technique maps each power of 2 to a unique
+    /// index in the lookup table.
+    /// Credit to adhusson: https://blog.adhusson.com/cheap-find-first-set-evm/
     /// @param x the value for which to compute the least significant bit, must be greater than 0
-    /// @return r the index of the least significant bit
+    /// @return r the index of the least significant bit (0-255)
     function leastSignificantBit(uint256 x) internal pure returns (uint8 r) {
         require(x > 0);
 
         assembly ("memory-safe") {
-            // Isolate the least significant bit.
+            // Isolate the least significant bit: x & (-x) = x & (two's complement of x)
+            // This leaves only the rightmost 1 bit set
             x := and(x, sub(0, x))
-            // For the upper 3 bits of the result, use a De Bruijn-like lookup.
-            // Credit to adhusson: https://blog.adhusson.com/cheap-find-first-set-evm/
+            
+            // De Bruijn multiplication technique for upper 3 bits (determines which 32-bit section)
+            // The magic constant maps each power of 2 to a unique 3-bit section index
             // forgefmt: disable-next-item
             r := shl(5, shr(252, shl(shl(2, shr(250, mul(x,
                 0xb6db6db6ddddddddd34d34d349249249210842108c6318c639ce739cffffffff))),
                 0x8040405543005266443200005020610674053026020000107506200176117077)))
-            // For the lower 5 bits of the result, use a De Bruijn lookup.
+            
+            // De Bruijn lookup for lower 5 bits (precise position within the 32-bit section)
+            // 0xd76453e0 is the De Bruijn constant, lookup table maps to exact bit position
             // forgefmt: disable-next-item
             r := or(r, byte(and(div(0xd76453e0, shr(r, x)), 0x1f),
                 0x001f0d1e100c1d070f090b19131c1706010e11080a1a141802121b1503160405))

--- a/src/libraries/CurrencyDelta.sol
+++ b/src/libraries/CurrencyDelta.sol
@@ -3,28 +3,51 @@ pragma solidity ^0.8.24;
 
 import {Currency} from "../types/Currency.sol";
 
-/// @title a library to store callers' currency deltas in transient storage
-/// @dev this library implements the equivalent of a mapping, as transient storage can only be accessed in assembly
+/// @title CurrencyDelta
+/// @notice A library to store callers' currency deltas in transient storage
+/// @dev This library implements the equivalent of a mapping, as transient storage can only be accessed in assembly.
+/// Currency deltas track the balance changes for each (account, currency) pair during an unlock callback.
+/// Positive deltas mean the account is owed tokens by the pool, negative means they owe tokens to the pool.
+/// All deltas must be settled (reach zero) before the unlock completes.
+/// @custom:security Transient storage is automatically cleared at the end of each transaction.
 library CurrencyDelta {
-    /// @notice calculates which storage slot a delta should be stored in for a given account and currency
+    /// @notice Calculates the transient storage slot for a given account and currency delta
+    /// @dev Uses keccak256(target || currency) to derive a unique slot for each (account, currency) pair.
+    /// This prevents collisions between different accounts and currencies.
+    /// @param target The address whose delta is being tracked
+    /// @param currency The currency for which the delta is being tracked
+    /// @return hashSlot The computed storage slot
     function _computeSlot(address target, Currency currency) internal pure returns (bytes32 hashSlot) {
         assembly ("memory-safe") {
+            // Store target address in first 32 bytes (right-padded), masking to 160 bits
             mstore(0, and(target, 0xffffffffffffffffffffffffffffffffffffffff))
+            // Store currency address in second 32 bytes, masking to 160 bits
             mstore(32, and(currency, 0xffffffffffffffffffffffffffffffffffffffff))
+            // Hash both values together to get unique slot
             hashSlot := keccak256(0, 64)
         }
     }
 
+    /// @notice Gets the current delta for a currency and account
+    /// @dev Reads from transient storage at the computed slot
+    /// @param currency The currency to check
+    /// @param target The account to check
+    /// @return delta The current delta (positive = owed to account, negative = owed by account)
     function getDelta(Currency currency, address target) internal view returns (int256 delta) {
         bytes32 hashSlot = _computeSlot(target, currency);
         assembly ("memory-safe") {
+            // Load delta from transient storage
             delta := tload(hashSlot)
         }
     }
 
-    /// @notice applies a new currency delta for a given account and currency
-    /// @return previous The prior value
-    /// @return next The modified result
+    /// @notice Applies a new currency delta for a given account and currency
+    /// @dev Adds the delta to the existing value in transient storage
+    /// @param currency The currency being modified
+    /// @param target The account whose delta is being modified
+    /// @param delta The amount to add to the current delta (can be negative)
+    /// @return previous The prior delta value
+    /// @return next The new delta value after applying the change
     function applyDelta(Currency currency, address target, int128 delta)
         internal
         returns (int256 previous, int256 next)
@@ -32,10 +55,13 @@ library CurrencyDelta {
         bytes32 hashSlot = _computeSlot(target, currency);
 
         assembly ("memory-safe") {
+            // Load current delta
             previous := tload(hashSlot)
         }
+        // Compute new delta (addition happens outside assembly for clarity)
         next = previous + delta;
         assembly ("memory-safe") {
+            // Store updated delta
             tstore(hashSlot, next)
         }
     }

--- a/src/libraries/CurrencyReserves.sol
+++ b/src/libraries/CurrencyReserves.sol
@@ -7,9 +7,11 @@ import {CustomRevert} from "./CustomRevert.sol";
 library CurrencyReserves {
     using CustomRevert for bytes4;
 
-    /// bytes32(uint256(keccak256("ReservesOf")) - 1)
+    /// @dev The slot holding the reserves of the synced currency.
+    /// Calculated as `bytes32(uint256(keccak256("ReservesOf")) - 1)` to effectively namespace the slot and avoid collisions.
     bytes32 constant RESERVES_OF_SLOT = 0x1e0745a7db1623981f0b2a5d4232364c00787266eb75ad546f190e6cebe9bd95;
-    /// bytes32(uint256(keccak256("Currency")) - 1)
+    /// @dev The slot holding the currently synced currency.
+    /// Calculated as `bytes32(uint256(keccak256("Currency")) - 1)` to effectively namespace the slot and avoid collisions.
     bytes32 constant CURRENCY_SLOT = 0x27e098c505d44ec3574004bca052aabf76bd35004c182099d8c575fb238593b9;
 
     function getSyncedCurrency() internal view returns (Currency currency) {

--- a/src/libraries/CurrencyReserves.sol
+++ b/src/libraries/CurrencyReserves.sol
@@ -4,37 +4,81 @@ pragma solidity ^0.8.24;
 import {Currency} from "../types/Currency.sol";
 import {CustomRevert} from "./CustomRevert.sol";
 
+/// @title CurrencyReserves
+/// @author Uniswap Labs
+/// @notice Library for managing synced currency and reserve tracking using EIP-1153 transient storage
+/// @dev This library provides transient storage (TSTORE/TLOAD) operations for tracking
+/// the currently synced currency and its reserves during a transaction. Transient storage
+/// is automatically cleared at the end of each transaction, making it ideal for
+/// temporary state that only needs to persist within a single transaction.
+///
+/// The library uses namespaced storage slots calculated as `keccak256(name) - 1` to avoid
+/// collisions with other storage variables.
+///
+/// Key concepts:
+/// - Synced currency: The currency being tracked for balance verification
+/// - Reserves: The expected balance of the synced currency
+/// - These values are used to verify that balance changes match expected deltas
 library CurrencyReserves {
     using CustomRevert for bytes4;
 
-    /// @dev The slot holding the reserves of the synced currency.
-    /// Calculated as `bytes32(uint256(keccak256("ReservesOf")) - 1)` to effectively namespace the slot and avoid collisions.
+    /// @dev The transient storage slot holding the reserves of the synced currency.
+    /// @dev Calculated as `bytes32(uint256(keccak256("ReservesOf")) - 1)` to effectively
+    /// namespace the slot and avoid collisions with other storage variables.
     bytes32 constant RESERVES_OF_SLOT = 0x1e0745a7db1623981f0b2a5d4232364c00787266eb75ad546f190e6cebe9bd95;
-    /// @dev The slot holding the currently synced currency.
-    /// Calculated as `bytes32(uint256(keccak256("Currency")) - 1)` to effectively namespace the slot and avoid collisions.
+
+    /// @dev The transient storage slot holding the currently synced currency address.
+    /// @dev Calculated as `bytes32(uint256(keccak256("Currency")) - 1)` to effectively
+    /// namespace the slot and avoid collisions with other storage variables.
     bytes32 constant CURRENCY_SLOT = 0x27e098c505d44ec3574004bca052aabf76bd35004c182099d8c575fb238593b9;
 
+    /// @notice Retrieves the currently synced currency from transient storage
+    /// @dev Uses TLOAD opcode (EIP-1153) to read from transient storage.
+    /// The value is automatically cleared at the end of the transaction.
+    /// @return currency The Currency type representing the synced currency address
     function getSyncedCurrency() internal view returns (Currency currency) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // TLOAD reads from transient storage at CURRENCY_SLOT
             currency := tload(CURRENCY_SLOT)
         }
     }
 
+    /// @notice Resets the synced currency to address(0) in transient storage
+    /// @dev Uses TSTORE opcode (EIP-1153) to clear the currency slot.
+    /// This is typically called after completing sync verification to clean up state.
     function resetCurrency() internal {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // TSTORE writes 0 to clear the transient storage slot
             tstore(CURRENCY_SLOT, 0)
         }
     }
 
+    /// @notice Atomically sets both the synced currency and its reserves in transient storage
+    /// @dev Uses TSTORE opcode (EIP-1153) to write to transient storage.
+    /// The currency address is masked to 160 bits to ensure proper address formatting.
+    /// Both values are set in a single function call to maintain consistency.
+    /// @param currency The currency to sync (will be masked to 160 bits)
+    /// @param value The reserve amount to store for the synced currency
     function syncCurrencyAndReserves(Currency currency, uint256 value) internal {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Mask currency to 160 bits (address size) and store in CURRENCY_SLOT
             tstore(CURRENCY_SLOT, and(currency, 0xffffffffffffffffffffffffffffffffffffffff))
+            // Store the reserve value in RESERVES_OF_SLOT
             tstore(RESERVES_OF_SLOT, value)
         }
     }
 
+    /// @notice Retrieves the current reserves of the synced currency from transient storage
+    /// @dev Uses TLOAD opcode (EIP-1153) to read from transient storage.
+    /// This value represents the expected/tracked balance of the synced currency.
+    /// @return value The reserve amount stored for the synced currency
     function getSyncedReserves() internal view returns (uint256 value) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // TLOAD reads from transient storage at RESERVES_OF_SLOT
             value := tload(RESERVES_OF_SLOT)
         }
     }

--- a/src/libraries/FixedPoint128.sol
+++ b/src/libraries/FixedPoint128.sol
@@ -2,7 +2,18 @@
 pragma solidity ^0.8.0;
 
 /// @title FixedPoint128
-/// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)
+/// @notice A library for handling binary fixed point numbers in Q128 format
+/// @dev This library provides the Q128 constant used for fixed-point arithmetic with 128 fractional bits.
+/// The Q128 format represents numbers as: value = rawValue / 2^128
+/// This is primarily used in Uniswap v4 for tracking fee growth per unit of liquidity,
+/// where high precision is required to accurately accumulate fees over many transactions.
+/// See https://en.wikipedia.org/wiki/Q_(number_format) for more information on Q number formats.
 library FixedPoint128 {
+    /// @notice The Q128 constant representing 2^128
+    /// @dev Used as the denominator in Q128 fixed-point calculations.
+    /// Q128 = 2^128 = 340282366920938463463374607431768211456
+    /// In hex: 0x100000000000000000000000000000000 (1 followed by 32 zeros)
+    /// @dev Example usage: To convert a Q128 value to a regular number, divide by Q128
+    /// realValue = q128Value / Q128
     uint256 internal constant Q128 = 0x100000000000000000000000000000000;
 }

--- a/src/libraries/FixedPoint96.sol
+++ b/src/libraries/FixedPoint96.sol
@@ -2,9 +2,23 @@
 pragma solidity ^0.8.0;
 
 /// @title FixedPoint96
-/// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)
-/// @dev Used in SqrtPriceMath.sol
+/// @notice A library for handling binary fixed point numbers in Q96 format
+/// @dev This library provides constants for fixed-point arithmetic with 96 fractional bits.
+/// The Q96 format represents numbers as: value = rawValue / 2^96
+/// This format is central to Uniswap v4's price representation, where prices are stored as
+/// sqrtPriceX96 = sqrt(price) * 2^96. This allows for efficient price calculations while
+/// maintaining high precision across a wide range of token price ratios.
+/// See https://en.wikipedia.org/wiki/Q_(number_format) for more information on Q number formats.
 library FixedPoint96 {
+    /// @notice The number of fractional bits in a Q96 fixed-point number
+    /// @dev 96 bits of resolution provides approximately 29 decimal digits of precision
     uint8 internal constant RESOLUTION = 96;
+
+    /// @notice The Q96 constant representing 2^96
+    /// @dev Used as the denominator in Q96 fixed-point calculations.
+    /// Q96 = 2^96 = 79228162514264337593543950336
+    /// In hex: 0x1000000000000000000000000 (1 followed by 24 zeros)
+    /// @dev Example: sqrtPriceX96 uses this format, so to get the actual sqrt price:
+    /// sqrtPrice = sqrtPriceX96 / Q96
     uint256 internal constant Q96 = 0x1000000000000000000000000;
 }

--- a/src/libraries/LiquidityMath.sol
+++ b/src/libraries/LiquidityMath.sol
@@ -2,16 +2,30 @@
 pragma solidity ^0.8.0;
 
 /// @title Math library for liquidity
+/// @notice Provides utility functions for liquidity calculations in Uniswap v4
+/// @dev This library handles safe arithmetic operations for liquidity amounts,
+/// which are represented as uint128 values. The primary function addDelta
+/// allows both adding and subtracting liquidity using a signed delta value.
 library LiquidityMath {
     /// @notice Add a signed liquidity delta to liquidity and revert if it overflows or underflows
-    /// @param x The liquidity before change
-    /// @param y The delta by which liquidity should be changed
-    /// @return z The liquidity delta
+    /// @dev This function safely handles both positive and negative deltas:
+    /// - Positive delta: adds liquidity (minting)
+    /// - Negative delta: removes liquidity (burning)
+    /// Uses assembly for gas optimization and to handle edge cases with int128.min
+    /// @param x The current liquidity before the change (uint128)
+    /// @param y The delta by which liquidity should be changed (int128, can be negative)
+    /// @return z The new liquidity after applying the delta
+    /// @custom:error SafeCastOverflow Reverts if the result would overflow uint128 or underflow below 0
     function addDelta(uint128 x, int128 y) internal pure returns (uint128 z) {
         assembly ("memory-safe") {
+            // Mask x to 128 bits and sign-extend y from 128 bits to 256 bits
+            // signextend(15, y) extends the sign bit of byte 15 (the 128th bit) across the upper bits
             z := add(and(x, 0xffffffffffffffffffffffffffffffff), signextend(15, y))
+            // Check if result exceeds uint128 max by checking if any bits above position 128 are set
+            // If shr(128, z) is non-zero, the result overflowed uint128 bounds
             if shr(128, z) {
                 // revert SafeCastOverflow()
+                // Selector: 0x93dafdf1 = bytes4(keccak256("SafeCastOverflow()"))
                 mstore(0, 0x93dafdf1)
                 revert(0x1c, 0x04)
             }

--- a/src/libraries/Lock.sol
+++ b/src/libraries/Lock.sol
@@ -1,28 +1,48 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
 
-/// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
-/// @dev TODO: This library can be deleted when the `transient` keyword is fully supported and stabilized in Solidity.
+/// @title Lock
+/// @notice Manages the unlock state of the PoolManager using transient storage
+/// @dev This is a temporary library that allows us to use transient storage (tstore/tload)
+/// for managing the lock state of the PoolManager during callback execution.
+/// The unlock state ensures that pool actions can only be performed within a valid callback context.
+/// TODO: This library can be deleted when the `transient` keyword is fully supported and stabilized in Solidity.
 /// Currently, assembly is used to access the `tstore` and `tload` opcodes directly for gas efficiency and availability.
+/// @custom:security Transient storage is automatically cleared at the end of each transaction,
+/// ensuring the PoolManager is locked by default at the start of each transaction.
 library Lock {
-    // The slot holding the unlocked state, transiently. bytes32(uint256(keccak256("Unlocked")) - 1)
+    /// @notice The transient storage slot for the unlock state
+    /// @dev Derived from: bytes32(uint256(keccak256("Unlocked")) - 1)
+    /// Subtracting 1 ensures the slot doesn't collide with standard storage patterns
     bytes32 internal constant IS_UNLOCKED_SLOT = 0xc090fc4683624cfc3884e9d8de5eca132f2d0ec062aff75d43c0465d5ceeab23;
 
+    /// @notice Sets the PoolManager state to unlocked
+    /// @dev Called at the beginning of the unlock callback to enable pool operations.
+    /// Uses tstore opcode to write to transient storage.
     function unlock() internal {
         assembly ("memory-safe") {
-            // unlock
+            // Set unlock state to true (1) in transient storage
             tstore(IS_UNLOCKED_SLOT, true)
         }
     }
 
+    /// @notice Sets the PoolManager state to locked
+    /// @dev Called at the end of the unlock callback to disable pool operations.
+    /// This ensures the PoolManager is properly secured after callback completion.
     function lock() internal {
         assembly ("memory-safe") {
+            // Set unlock state to false (0) in transient storage
             tstore(IS_UNLOCKED_SLOT, false)
         }
     }
 
+    /// @notice Checks if the PoolManager is currently unlocked
+    /// @dev Used to verify that pool operations are being called within a valid callback context.
+    /// Returns false by default (when transient storage hasn't been written to).
+    /// @return unlocked True if the PoolManager is unlocked, false otherwise
     function isUnlocked() internal view returns (bool unlocked) {
         assembly ("memory-safe") {
+            // Load unlock state from transient storage
             unlocked := tload(IS_UNLOCKED_SLOT)
         }
     }

--- a/src/libraries/Lock.sol
+++ b/src/libraries/Lock.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.24;
 
 /// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
-/// TODO: This library can be deleted when we have the transient keyword support in solidity.
+/// @dev TODO: This library can be deleted when the `transient` keyword is fully supported and stabilized in Solidity.
+/// Currently, assembly is used to access the `tstore` and `tload` opcodes directly for gas efficiency and availability.
 library Lock {
     // The slot holding the unlocked state, transiently. bytes32(uint256(keccak256("Unlocked")) - 1)
     bytes32 internal constant IS_UNLOCKED_SLOT = 0xc090fc4683624cfc3884e9d8de5eca132f2d0ec062aff75d43c0465d5ceeab23;

--- a/src/libraries/NonzeroDeltaCount.sol
+++ b/src/libraries/NonzeroDeltaCount.sol
@@ -1,33 +1,52 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
 
-/// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
-/// for the nonzero delta count.
-/// @dev TODO: This library can be deleted when the `transient` keyword is fully supported and stabilized in Solidity.
+/// @title NonzeroDeltaCount
+/// @notice Tracks the count of non-zero currency deltas using transient storage
+/// @dev This is a temporary library that allows us to use transient storage (tstore/tload)
+/// for tracking the number of currencies with non-zero deltas during an unlock callback.
+/// The count is used to ensure all deltas are settled before the unlock completes.
+/// TODO: This library can be deleted when the `transient` keyword is fully supported and stabilized in Solidity.
 /// Currently, assembly is used to access the `tstore` and `tload` opcodes directly for gas efficiency and availability.
+/// @custom:security Transient storage is automatically cleared at the end of each transaction.
 library NonzeroDeltaCount {
-    // The slot holding the number of nonzero deltas. bytes32(uint256(keccak256("NonzeroDeltaCount")) - 1)
+    /// @notice The transient storage slot for the nonzero delta count
+    /// @dev Derived from: bytes32(uint256(keccak256("NonzeroDeltaCount")) - 1)
+    /// Subtracting 1 ensures the slot doesn't collide with standard storage patterns
     bytes32 internal constant NONZERO_DELTA_COUNT_SLOT =
         0x7d4b3164c6e45b97e7d87b7125a44c5828d005af88f9d751cfd78729c5d99a0b;
 
+    /// @notice Reads the current count of currencies with non-zero deltas
+    /// @dev Uses tload opcode to read from transient storage
+    /// @return count The current number of currencies with non-zero deltas
     function read() internal view returns (uint256 count) {
         assembly ("memory-safe") {
+            // Load count from transient storage
             count := tload(NONZERO_DELTA_COUNT_SLOT)
         }
     }
 
+    /// @notice Increments the count of currencies with non-zero deltas
+    /// @dev Called when a currency's delta changes from zero to non-zero
+    /// Uses tload/tstore opcodes for transient storage operations
     function increment() internal {
         assembly ("memory-safe") {
+            // Load current count, add 1, store back
             let count := tload(NONZERO_DELTA_COUNT_SLOT)
             count := add(count, 1)
             tstore(NONZERO_DELTA_COUNT_SLOT, count)
         }
     }
 
-    /// @notice Potential to underflow. Ensure checks are performed by integrating contracts to ensure this does not happen.
-    /// Current usage ensures this will not happen because we call decrement with known boundaries (only up to the number of times we call increment).
+    /// @notice Decrements the count of currencies with non-zero deltas
+    /// @dev Called when a currency's delta changes from non-zero to zero.
+    /// WARNING: Potential to underflow. Ensure checks are performed by integrating contracts.
+    /// Current usage ensures this will not happen because we call decrement with known boundaries
+    /// (only up to the number of times we call increment).
     function decrement() internal {
         assembly ("memory-safe") {
+            // Load current count, subtract 1, store back
+            // WARNING: No underflow check - caller must ensure count > 0
             let count := tload(NONZERO_DELTA_COUNT_SLOT)
             count := sub(count, 1)
             tstore(NONZERO_DELTA_COUNT_SLOT, count)

--- a/src/libraries/NonzeroDeltaCount.sol
+++ b/src/libraries/NonzeroDeltaCount.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.24;
 
 /// @notice This is a temporary library that allows us to use transient storage (tstore/tload)
 /// for the nonzero delta count.
-/// TODO: This library can be deleted when we have the transient keyword support in solidity.
+/// @dev TODO: This library can be deleted when the `transient` keyword is fully supported and stabilized in Solidity.
+/// Currently, assembly is used to access the `tstore` and `tload` opcodes directly for gas efficiency and availability.
 library NonzeroDeltaCount {
     // The slot holding the number of nonzero deltas. bytes32(uint256(keccak256("NonzeroDeltaCount")) - 1)
     bytes32 internal constant NONZERO_DELTA_COUNT_SLOT =

--- a/src/libraries/ParseBytes.sol
+++ b/src/libraries/ParseBytes.sol
@@ -2,27 +2,54 @@
 
 pragma solidity ^0.8.0;
 
-/// @notice Parses bytes returned from hooks and the byte selector used to check return selectors from hooks.
-/// @dev parseSelector also is used to parse the expected selector
-/// For parsing hook returns, note that all hooks return either bytes4 or (bytes4, 32-byte-delta) or (bytes4, 32-byte-delta, uint24).
+/// @title ParseBytes
+/// @notice Parses bytes returned from hooks and the byte selector used to check return selectors from hooks
+/// @dev This library provides efficient parsing utilities for hook return values.
+/// Hooks in Uniswap v4 return packed data that needs to be efficiently unpacked.
+/// The return formats are:
+/// - bytes4 only: Just the selector for validation
+/// - (bytes4, int256): Selector and a 32-byte delta value
+/// - (bytes4, int256, uint24): Selector, delta, and LP fee
+/// All parsing uses assembly for gas efficiency since these are called frequently.
 library ParseBytes {
+    /// @notice Extracts the selector (first 4 bytes) from hook return data
+    /// @dev Used to validate that hooks return the expected selector.
+    /// Also used to parse the expected selector for comparison.
+    /// @param result The bytes data returned from a hook call
+    /// @return selector The first 4 bytes of the result, representing the function selector
     function parseSelector(bytes memory result) internal pure returns (bytes4 selector) {
         // equivalent: (selector,) = abi.decode(result, (bytes4, int256));
         assembly ("memory-safe") {
+            // Load 32 bytes starting at position 0x20 (after the length prefix)
+            // Only the first 4 bytes contain the selector, rest is padding
             selector := mload(add(result, 0x20))
         }
     }
 
+    /// @notice Extracts the LP fee from hook return data
+    /// @dev Used to get the dynamic LP fee returned by beforeSwap hooks.
+    /// The fee is located at the third 32-byte slot in the return data.
+    /// @param result The bytes data returned from a hook call (must be at least 96 bytes)
+    /// @return lpFee The LP fee in hundredths of a bip (e.g., 3000 = 0.30%)
     function parseFee(bytes memory result) internal pure returns (uint24 lpFee) {
         // equivalent: (,, lpFee) = abi.decode(result, (bytes4, int256, uint24));
         assembly ("memory-safe") {
+            // Load from position 0x60 (0x20 length + 0x20 selector + 0x20 delta)
+            // The uint24 is right-aligned in the 32-byte slot
             lpFee := mload(add(result, 0x60))
         }
     }
 
+    /// @notice Extracts the return delta from hook return data
+    /// @dev Used to get the hook's delta modification from beforeSwap/afterSwap hooks.
+    /// The delta represents how much the hook wants to modify the swap amounts.
+    /// @param result The bytes data returned from a hook call (must be at least 64 bytes)
+    /// @return hookReturn The int256 delta value returned by the hook
     function parseReturnDelta(bytes memory result) internal pure returns (int256 hookReturn) {
         // equivalent: (, hookReturnDelta) = abi.decode(result, (bytes4, int256));
         assembly ("memory-safe") {
+            // Load from position 0x40 (0x20 length + 0x20 selector slot)
+            // The full 32 bytes represent the int256 value
             hookReturn := mload(add(result, 0x40))
         }
     }

--- a/src/libraries/SafeCast.sol
+++ b/src/libraries/SafeCast.sol
@@ -5,12 +5,17 @@ import {CustomRevert} from "./CustomRevert.sol";
 
 /// @title Safe casting methods
 /// @notice Contains methods for safely casting between types
+/// @dev These functions revert with SafeCastOverflow if the cast would result in data loss.
+/// This library is essential for safely converting between different integer sizes in Uniswap v4,
+/// particularly when working with packed storage formats and balance calculations.
 library SafeCast {
     using CustomRevert for bytes4;
 
+    /// @notice Thrown when a cast would overflow or underflow the target type
     error SafeCastOverflow();
 
     /// @notice Cast a uint256 to a uint160, revert on overflow
+    /// @dev Used for safely converting to address-sized integers (e.g., sqrtPriceX96 bounds)
     /// @param x The uint256 to be downcasted
     /// @return y The downcasted integer, now type uint160
     function toUint160(uint256 x) internal pure returns (uint160 y) {
@@ -19,6 +24,7 @@ library SafeCast {
     }
 
     /// @notice Cast a uint256 to a uint128, revert on overflow
+    /// @dev Used for safely converting to liquidity amounts which are stored as uint128
     /// @param x The uint256 to be downcasted
     /// @return y The downcasted integer, now type uint128
     function toUint128(uint256 x) internal pure returns (uint128 y) {
@@ -27,6 +33,7 @@ library SafeCast {
     }
 
     /// @notice Cast a int128 to a uint128, revert on overflow or underflow
+    /// @dev Converts signed to unsigned, reverting if the input is negative
     /// @param x The int128 to be casted
     /// @return y The casted integer, now type uint128
     function toUint128(int128 x) internal pure returns (uint128 y) {
@@ -35,6 +42,7 @@ library SafeCast {
     }
 
     /// @notice Cast a int256 to a int128, revert on overflow or underflow
+    /// @dev Used when extracting int128 values from packed int256 representations
     /// @param x The int256 to be downcasted
     /// @return y The downcasted integer, now type int128
     function toInt128(int256 x) internal pure returns (int128 y) {
@@ -43,6 +51,7 @@ library SafeCast {
     }
 
     /// @notice Cast a uint256 to a int256, revert on overflow
+    /// @dev Converts unsigned to signed, reverting if the value exceeds int256.max
     /// @param x The uint256 to be casted
     /// @return y The casted integer, now type int256
     function toInt256(uint256 x) internal pure returns (int256 y) {
@@ -51,10 +60,12 @@ library SafeCast {
     }
 
     /// @notice Cast a uint256 to a int128, revert on overflow
+    /// @dev Combines downcasting and sign conversion in one operation
+    /// Reverts if x >= 2^127 (the maximum value of int128 + 1)
     /// @param x The uint256 to be downcasted
-    /// @return The downcasted integer, now type int128
-    function toInt128(uint256 x) internal pure returns (int128) {
+    /// @return y The downcasted integer, now type int128
+    function toInt128(uint256 x) internal pure returns (int128 y) {
         if (x >= 1 << 127) SafeCastOverflow.selector.revertWith();
-        return int128(int256(x));
+        y = int128(int256(x));
     }
 }

--- a/src/libraries/UnsafeMath.sol
+++ b/src/libraries/UnsafeMath.sol
@@ -3,26 +3,39 @@ pragma solidity ^0.8.0;
 
 /// @title Math functions that do not check inputs or outputs
 /// @notice Contains methods that perform common math functions but do not do any overflow or underflow checks
+/// @dev WARNING: This library is intentionally unsafe and should only be used when the caller
+/// has already validated inputs or when the specific behavior (like returning 0 for division by 0)
+/// is explicitly desired. For safe math operations, consider using FullMath or OpenZeppelin's Math.
+/// The functions in this library are gas-optimized using inline assembly and skip safety checks
+/// that would normally prevent undefined or erroneous behavior.
+/// @custom:security-contact security@uniswap.org
 library UnsafeMath {
     /// @notice Returns ceil(x / y)
-    /// @dev division by 0 will return 0, and should be checked externally
+    /// @dev WARNING: Division by 0 will return 0, not revert. This behavior should be checked externally.
+    /// This function is useful when you've already validated that y != 0 and want to save gas on the check.
     /// @param x The dividend
-    /// @param y The divisor
-    /// @return z The quotient, ceil(x / y)
+    /// @param y The divisor (must be validated externally to be non-zero if a revert is desired)
+    /// @return z The quotient, ceil(x / y), or 0 if y is 0
     function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly ("memory-safe") {
+            // Compute x / y + (x % y > 0 ? 1 : 0) to get ceiling division
+            // gt(mod(x, y), 0) returns 1 if there's a remainder, 0 otherwise
             z := add(div(x, y), gt(mod(x, y), 0))
         }
     }
 
     /// @notice Calculates floor(a×b÷denominator)
-    /// @dev division by 0 will return 0, and should be checked externally
+    /// @dev WARNING: Division by 0 will return 0, not revert. This behavior should be checked externally.
+    /// WARNING: This function can silently overflow if a * b > type(uint256).max.
+    /// Use FullMath.mulDiv for cases where overflow is possible and must be handled correctly.
     /// @param a The multiplicand
     /// @param b The multiplier
-    /// @param denominator The divisor
-    /// @return result The 256-bit result, floor(a×b÷denominator)
+    /// @param denominator The divisor (must be validated externally to be non-zero if a revert is desired)
+    /// @return result The 256-bit result, floor(a×b÷denominator), or 0 if denominator is 0
     function simpleMulDiv(uint256 a, uint256 b, uint256 denominator) internal pure returns (uint256 result) {
         assembly ("memory-safe") {
+            // Simple multiplication followed by division
+            // WARNING: mul(a, b) can overflow, results in truncated lower 256 bits
             result := div(mul(a, b), denominator)
         }
     }

--- a/src/types/BalanceDelta.sol
+++ b/src/types/BalanceDelta.sol
@@ -3,69 +3,123 @@ pragma solidity ^0.8.0;
 
 import {SafeCast} from "../libraries/SafeCast.sol";
 
+/// @title BalanceDelta
+/// @notice Represents the balance changes for a pool operation, encoding two int128 values in a single int256
 /// @dev Two `int128` values packed into a single `int256` where the upper 128 bits represent the amount0
 /// and the lower 128 bits represent the amount1.
+/// This packing is used throughout Uniswap v4 to efficiently pass balance deltas in a single word.
+/// Positive values indicate tokens owed TO the caller, negative values indicate tokens owed BY the caller.
 type BalanceDelta is int256;
 
 using {add as +, sub as -, eq as ==, neq as !=} for BalanceDelta global;
 using BalanceDeltaLibrary for BalanceDelta global;
 using SafeCast for int256;
 
+/// @notice Creates a BalanceDelta from two int128 amounts
+/// @dev Packs amount0 into upper 128 bits and amount1 into lower 128 bits.
+/// Uses assembly for gas-efficient bit manipulation.
+/// @param _amount0 The balance delta for token0 (will be stored in upper 128 bits)
+/// @param _amount1 The balance delta for token1 (will be stored in lower 128 bits)
+/// @return balanceDelta The packed BalanceDelta value
 function toBalanceDelta(int128 _amount0, int128 _amount1) pure returns (BalanceDelta balanceDelta) {
     assembly ("memory-safe") {
+        // Shift amount0 left by 128 bits to occupy upper half
+        // Mask amount1 to 128 bits and OR with shifted amount0
+        // sub(shl(128, 1), 1) creates a 128-bit mask (0xFFFF...FFFF)
         balanceDelta := or(shl(128, _amount0), and(sub(shl(128, 1), 1), _amount1))
     }
 }
 
+/// @notice Adds two BalanceDeltas together
+/// @dev Extracts both components from each delta, adds them, then repacks.
+/// Uses SafeCast to ensure the sums fit in int128.
+/// @param a The first BalanceDelta
+/// @param b The second BalanceDelta
+/// @return The sum of the two BalanceDeltas
 function add(BalanceDelta a, BalanceDelta b) pure returns (BalanceDelta) {
     int256 res0;
     int256 res1;
     assembly ("memory-safe") {
+        // Extract amount0 from upper 128 bits using arithmetic right shift (preserves sign)
         let a0 := sar(128, a)
+        // Extract amount1 from lower 128 bits using sign extension
         let a1 := signextend(15, a)
         let b0 := sar(128, b)
         let b1 := signextend(15, b)
+        // Sum the components
         res0 := add(a0, b0)
         res1 := add(a1, b1)
     }
+    // SafeCast to int128 to ensure no overflow
     return toBalanceDelta(res0.toInt128(), res1.toInt128());
 }
 
+/// @notice Subtracts one BalanceDelta from another
+/// @dev Extracts both components from each delta, subtracts them, then repacks.
+/// Uses SafeCast to ensure the differences fit in int128.
+/// @param a The BalanceDelta to subtract from
+/// @param b The BalanceDelta to subtract
+/// @return The difference of the two BalanceDeltas
 function sub(BalanceDelta a, BalanceDelta b) pure returns (BalanceDelta) {
     int256 res0;
     int256 res1;
     assembly ("memory-safe") {
+        // Extract amount0 from upper 128 bits using arithmetic right shift (preserves sign)
         let a0 := sar(128, a)
+        // Extract amount1 from lower 128 bits using sign extension
         let a1 := signextend(15, a)
         let b0 := sar(128, b)
         let b1 := signextend(15, b)
+        // Subtract the components
         res0 := sub(a0, b0)
         res1 := sub(a1, b1)
     }
+    // SafeCast to int128 to ensure no underflow
     return toBalanceDelta(res0.toInt128(), res1.toInt128());
 }
 
+/// @notice Checks if two BalanceDeltas are equal
+/// @dev Compares the raw int256 values directly
+/// @param a The first BalanceDelta
+/// @param b The second BalanceDelta
+/// @return True if both BalanceDeltas are equal
 function eq(BalanceDelta a, BalanceDelta b) pure returns (bool) {
     return BalanceDelta.unwrap(a) == BalanceDelta.unwrap(b);
 }
 
+/// @notice Checks if two BalanceDeltas are not equal
+/// @dev Compares the raw int256 values directly
+/// @param a The first BalanceDelta
+/// @param b The second BalanceDelta
+/// @return True if the BalanceDeltas are not equal
 function neq(BalanceDelta a, BalanceDelta b) pure returns (bool) {
     return BalanceDelta.unwrap(a) != BalanceDelta.unwrap(b);
 }
 
 /// @notice Library for getting the amount0 and amount1 deltas from the BalanceDelta type
+/// @dev Provides extraction functions to unpack the two int128 values from the packed int256
 library BalanceDeltaLibrary {
-    /// @notice A BalanceDelta of 0
+    /// @notice A BalanceDelta of 0, representing no balance change
     BalanceDelta public constant ZERO_DELTA = BalanceDelta.wrap(0);
 
+    /// @notice Extracts the amount0 delta from a BalanceDelta
+    /// @dev Uses arithmetic right shift to extract upper 128 bits with sign preservation
+    /// @param balanceDelta The packed BalanceDelta value
+    /// @return _amount0 The token0 balance delta as int128
     function amount0(BalanceDelta balanceDelta) internal pure returns (int128 _amount0) {
         assembly ("memory-safe") {
+            // Arithmetic right shift by 128 bits extracts upper 128 bits with sign extension
             _amount0 := sar(128, balanceDelta)
         }
     }
 
+    /// @notice Extracts the amount1 delta from a BalanceDelta
+    /// @dev Uses sign extension to extract lower 128 bits as a signed value
+    /// @param balanceDelta The packed BalanceDelta value
+    /// @return _amount1 The token1 balance delta as int128
     function amount1(BalanceDelta balanceDelta) internal pure returns (int128 _amount1) {
         assembly ("memory-safe") {
+            // signextend(15, x) extends the sign bit at byte 15 (bit 127) to fill upper bits
             _amount1 := signextend(15, balanceDelta)
         }
     }

--- a/src/types/BeforeSwapDelta.sol
+++ b/src/types/BeforeSwapDelta.sol
@@ -1,37 +1,59 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Return type of the beforeSwap hook.
-// Upper 128 bits is the delta in specified tokens. Lower 128 bits is delta in unspecified tokens (to match the afterSwap hook)
+/// @title BeforeSwapDelta
+/// @notice Return type of the beforeSwap hook that encodes two int128 values in a single int256
+/// @dev The delta values are packed as follows:
+/// - Upper 128 bits: delta in specified tokens (the token the user is swapping from)
+/// - Lower 128 bits: delta in unspecified tokens (the token the user is swapping to)
+/// This packing matches the afterSwap hook format for consistency.
+/// Positive values indicate tokens owed TO the hook, negative values indicate tokens owed BY the hook.
 type BeforeSwapDelta is int256;
 
-// Creates a BeforeSwapDelta from specified and unspecified
+/// @notice Creates a BeforeSwapDelta from specified and unspecified token deltas
+/// @dev Packs two int128 values into a single int256 using bit manipulation.
+/// The specified delta is shifted to the upper 128 bits, and the unspecified delta
+/// occupies the lower 128 bits.
+/// @param deltaSpecified The delta for the specified token (upper 128 bits)
+/// @param deltaUnspecified The delta for the unspecified token (lower 128 bits)
+/// @return beforeSwapDelta The packed BeforeSwapDelta value
 function toBeforeSwapDelta(int128 deltaSpecified, int128 deltaUnspecified)
     pure
     returns (BeforeSwapDelta beforeSwapDelta)
 {
     assembly ("memory-safe") {
+        // Pack: shift specified left by 128 bits, OR with masked unspecified
+        // sub(shl(128, 1), 1) creates a 128-bit mask (0xFFFF...FFFF for lower 128 bits)
         beforeSwapDelta := or(shl(128, deltaSpecified), and(sub(shl(128, 1), 1), deltaUnspecified))
     }
 }
 
 /// @notice Library for getting the specified and unspecified deltas from the BeforeSwapDelta type
+/// @dev Provides extraction functions to unpack the two int128 values from the packed int256
 library BeforeSwapDeltaLibrary {
-    /// @notice A BeforeSwapDelta of 0
+    /// @notice A BeforeSwapDelta of 0, representing no delta changes
     BeforeSwapDelta public constant ZERO_DELTA = BeforeSwapDelta.wrap(0);
 
-    /// extracts int128 from the upper 128 bits of the BeforeSwapDelta
-    /// returned by beforeSwap
+    /// @notice Extracts the specified token delta from a BeforeSwapDelta
+    /// @dev Extracts int128 from the upper 128 bits using arithmetic right shift.
+    /// The arithmetic shift (sar) preserves the sign bit for negative values.
+    /// @param delta The packed BeforeSwapDelta value
+    /// @return deltaSpecified The specified token delta as int128
     function getSpecifiedDelta(BeforeSwapDelta delta) internal pure returns (int128 deltaSpecified) {
         assembly ("memory-safe") {
+            // Arithmetic right shift by 128 bits to get upper 128 bits with sign preservation
             deltaSpecified := sar(128, delta)
         }
     }
 
-    /// extracts int128 from the lower 128 bits of the BeforeSwapDelta
-    /// returned by beforeSwap and afterSwap
+    /// @notice Extracts the unspecified token delta from a BeforeSwapDelta
+    /// @dev Extracts int128 from the lower 128 bits using sign extension.
+    /// signextend(15, delta) extends the sign bit at position 127 to fill upper bits.
+    /// @param delta The packed BeforeSwapDelta value
+    /// @return deltaUnspecified The unspecified token delta as int128
     function getUnspecifiedDelta(BeforeSwapDelta delta) internal pure returns (int128 deltaUnspecified) {
         assembly ("memory-safe") {
+            // Sign extend from byte 15 (128th bit) to get signed lower 128 bits
             deltaUnspecified := signextend(15, delta)
         }
     }

--- a/src/types/Currency.sol
+++ b/src/types/Currency.sol
@@ -4,39 +4,86 @@ pragma solidity ^0.8.0;
 import {IERC20Minimal} from "../interfaces/external/IERC20Minimal.sol";
 import {CustomRevert} from "../libraries/CustomRevert.sol";
 
+/// @title Currency
+/// @notice A user-defined value type wrapping an address to represent a currency (native ETH or ERC20 token)
+/// @dev Currency wraps an address where:
+/// - address(0) represents the native currency (ETH on Ethereum mainnet)
+/// - Any other address represents an ERC20 token contract
+///
+/// This type provides type-safety and prevents accidental mixing of addresses and currencies.
+/// Global operators (==, >, <, >=) are defined for direct comparison.
+/// The CurrencyLibrary provides utility functions for transfers and balance queries.
 type Currency is address;
 
 using {greaterThan as >, lessThan as <, greaterThanOrEqualTo as >=, equals as ==} for Currency global;
 using CurrencyLibrary for Currency global;
 
+/// @notice Checks if two currencies are equal by comparing their underlying addresses
+/// @param currency The first currency to compare
+/// @param other The second currency to compare
+/// @return True if both currencies have the same underlying address
 function equals(Currency currency, Currency other) pure returns (bool) {
     return Currency.unwrap(currency) == Currency.unwrap(other);
 }
 
+/// @notice Checks if the first currency's address is greater than the second
+/// @dev Used for sorting currencies in pool keys where currency0 < currency1 is required
+/// @param currency The first currency to compare
+/// @param other The second currency to compare
+/// @return True if currency's address is numerically greater than other's address
 function greaterThan(Currency currency, Currency other) pure returns (bool) {
     return Currency.unwrap(currency) > Currency.unwrap(other);
 }
 
+/// @notice Checks if the first currency's address is less than the second
+/// @dev Used for sorting currencies in pool keys where currency0 < currency1 is required
+/// @param currency The first currency to compare
+/// @param other The second currency to compare
+/// @return True if currency's address is numerically less than other's address
 function lessThan(Currency currency, Currency other) pure returns (bool) {
     return Currency.unwrap(currency) < Currency.unwrap(other);
 }
 
+/// @notice Checks if the first currency's address is greater than or equal to the second
+/// @param currency The first currency to compare
+/// @param other The second currency to compare
+/// @return True if currency's address is numerically greater than or equal to other's address
 function greaterThanOrEqualTo(Currency currency, Currency other) pure returns (bool) {
     return Currency.unwrap(currency) >= Currency.unwrap(other);
 }
 
 /// @title CurrencyLibrary
-/// @dev This library allows for transferring and holding native tokens and ERC20 tokens
+/// @author Uniswap Labs
+/// @notice Library for transferring and querying balances of native ETH and ERC20 tokens
+/// @dev This library provides a unified interface for handling both native currency (ETH)
+/// and ERC20 tokens. It uses optimized assembly for gas efficiency and follows
+/// ERC-7751 for enhanced error handling with wrapped errors.
+///
+/// Key features:
+/// - Unified transfer interface for native ETH and ERC20 tokens
+/// - Gas-optimized ERC20 transfers using inline assembly
+/// - Balance queries for both self and arbitrary addresses
+/// - Currency ID conversion for efficient storage
 library CurrencyLibrary {
     /// @notice Additional context for ERC-7751 wrapped error when a native transfer fails
+    /// @dev Thrown when an ETH transfer via CALL opcode returns false
     error NativeTransferFailed();
 
     /// @notice Additional context for ERC-7751 wrapped error when an ERC20 transfer fails
+    /// @dev Thrown when an ERC20 transfer call fails or returns false
     error ERC20TransferFailed();
 
-    /// @notice A constant to represent the native currency
+    /// @notice A constant representing the native currency (ETH on mainnet)
+    /// @dev address(0) is used to represent native ETH throughout the protocol
     Currency public constant ADDRESS_ZERO = Currency.wrap(address(0));
 
+    /// @notice Transfers currency (native ETH or ERC20) to a recipient
+    /// @dev For native ETH: uses CALL opcode with value
+    /// For ERC20: uses optimized assembly to call transfer(address,uint256)
+    /// On failure, bubbles up the error with ERC-7751 wrapped context
+    /// @param currency The currency to transfer (address(0) for native ETH)
+    /// @param to The recipient address
+    /// @param amount The amount to transfer (in wei for ETH, smallest unit for ERC20)
     function transfer(Currency currency, address to, uint256 amount) internal {
         // altered from https://github.com/transmissions11/solmate/blob/44a9963d4c78111f77caa0e65d677b8b46d6f2e6/src/utils/SafeTransferLib.sol
         // modified custom error selectors
@@ -87,6 +134,11 @@ library CurrencyLibrary {
         }
     }
 
+    /// @notice Gets the balance of the currency held by the current contract
+    /// @dev For native ETH: returns address(this).balance
+    /// For ERC20: calls balanceOf(address(this)) on the token contract
+    /// @param currency The currency to query (address(0) for native ETH)
+    /// @return The balance of the currency held by this contract
     function balanceOfSelf(Currency currency) internal view returns (uint256) {
         if (currency.isAddressZero()) {
             return address(this).balance;
@@ -95,6 +147,12 @@ library CurrencyLibrary {
         }
     }
 
+    /// @notice Gets the balance of the currency held by a specific address
+    /// @dev For native ETH: returns owner.balance
+    /// For ERC20: calls balanceOf(owner) on the token contract
+    /// @param currency The currency to query (address(0) for native ETH)
+    /// @param owner The address to query the balance of
+    /// @return The balance of the currency held by the owner
     function balanceOf(Currency currency, address owner) internal view returns (uint256) {
         if (currency.isAddressZero()) {
             return owner.balance;
@@ -103,16 +161,29 @@ library CurrencyLibrary {
         }
     }
 
+    /// @notice Checks if the currency represents native ETH (address(0))
+    /// @param currency The currency to check
+    /// @return True if the currency is the native currency (address(0))
     function isAddressZero(Currency currency) internal pure returns (bool) {
         return Currency.unwrap(currency) == Currency.unwrap(ADDRESS_ZERO);
     }
 
+    /// @notice Converts a Currency to a uint256 ID for efficient storage
+    /// @dev Simply casts the underlying address to uint160, then to uint256
+    /// This is useful for using Currency as a mapping key
+    /// @param currency The currency to convert
+    /// @return The currency represented as a uint256 (only lower 160 bits used)
     function toId(Currency currency) internal pure returns (uint256) {
         return uint160(Currency.unwrap(currency));
     }
 
-    // If the upper 12 bytes are non-zero, they will be zero-ed out
-    // Therefore, fromId() and toId() are not inverses of each other
+    /// @notice Converts a uint256 ID back to a Currency
+    /// @dev Casts the uint256 to uint160, then wraps as an address
+    /// WARNING: If the upper 12 bytes of id are non-zero, they will be truncated.
+    /// Therefore, fromId(toId(currency)) == currency, but toId(fromId(id)) may not equal id
+    /// if the original id had non-zero upper bytes.
+    /// @param id The uint256 to convert (only lower 160 bits are used)
+    /// @return The Currency wrapping the address derived from the lower 160 bits
     function fromId(uint256 id) internal pure returns (Currency) {
         return Currency.wrap(address(uint160(id)));
     }

--- a/src/types/PoolId.sol
+++ b/src/types/PoolId.sol
@@ -3,14 +3,29 @@ pragma solidity ^0.8.0;
 
 import {PoolKey} from "./PoolKey.sol";
 
+/// @title PoolId
+/// @notice A unique identifier for a Uniswap v4 pool, derived from its PoolKey
+/// @dev PoolId is the keccak256 hash of the PoolKey struct, providing a gas-efficient
+/// way to identify and store pool data. This is used as the key in mappings throughout
+/// the PoolManager for O(1) pool lookups.
 type PoolId is bytes32;
 
 /// @notice Library for computing the ID of a pool
+/// @dev Provides a gas-optimized method to derive the PoolId from a PoolKey
 library PoolIdLibrary {
-    /// @notice Returns value equal to keccak256(abi.encode(poolKey))
+    /// @notice Computes the unique identifier for a pool given its key
+    /// @dev Returns value equal to keccak256(abi.encode(poolKey))
+    /// Uses assembly for gas efficiency, computing the hash directly from memory.
+    /// @param poolKey The PoolKey struct containing pool configuration
+    /// @return poolId The unique bytes32 identifier for the pool
     function toId(PoolKey memory poolKey) internal pure returns (PoolId poolId) {
         assembly ("memory-safe") {
-            // 0xa0 represents the total size of the poolKey struct (5 slots of 32 bytes)
+            // 0xa0 (160 bytes) represents the total size of the poolKey struct:
+            // - currency0: 32 bytes (address padded to 32)
+            // - currency1: 32 bytes (address padded to 32)
+            // - fee: 32 bytes (uint24 padded to 32)
+            // - tickSpacing: 32 bytes (int24 padded to 32)
+            // - hooks: 32 bytes (address padded to 32)
             poolId := keccak256(poolKey, 0xa0)
         }
     }

--- a/src/types/PoolOperation.sol
+++ b/src/types/PoolOperation.sol
@@ -5,22 +5,30 @@ import {PoolKey} from "../types/PoolKey.sol";
 import {BalanceDelta} from "../types/BalanceDelta.sol";
 
 /// @notice Parameter struct for `ModifyLiquidity` pool operations
+/// @dev Passed to modifyLiquidity to change the liquidity of a position
 struct ModifyLiquidityParams {
-    // the lower and upper tick of the position
+    /// @notice The lower tick of the position
     int24 tickLower;
+    /// @notice The upper tick of the position
     int24 tickUpper;
-    // how to modify the liquidity
+    /// @notice How to modify the liquidity
+    /// @dev Positive value adds liquidity, negative value removes liquidity
     int256 liquidityDelta;
-    // a value to set if you want unique liquidity positions at the same range
+    /// @notice A value to set if you want unique liquidity positions at the same range
+    /// @dev Allows distinguishing positions with the same ticks and owner
     bytes32 salt;
 }
 
 /// @notice Parameter struct for `Swap` pool operations
+/// @dev Passed to swap to execute a trade
 struct SwapParams {
-    /// Whether to swap token0 for token1 or vice versa
+    /// @notice Whether to swap token0 for token1 or vice versa
+    /// @dev true for token0 -> token1, false for token1 -> token0
     bool zeroForOne;
-    /// The desired input amount if negative (exactIn), or the desired output amount if positive (exactOut)
+    /// @notice The desired input amount if negative (exactIn), or the desired output amount if positive (exactOut)
+    /// @dev Negative value means exact input (paying this amount), positive means exact output (receiving this amount)
     int256 amountSpecified;
-    /// The sqrt price at which, if reached, the swap will stop executing
+    /// @notice The sqrt price at which, if reached, the swap will stop executing
+    /// @dev Used for slippage protection or specific price targeting
     uint160 sqrtPriceLimitX96;
 }

--- a/src/types/Slot0.sol
+++ b/src/types/Slot0.sol
@@ -1,82 +1,151 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/**
- * @dev Slot0 is a packed version of solidity structure.
- * Using the packaged version saves gas by not storing the structure fields in memory slots.
- *
- * Layout:
- * 24 bits empty | 24 bits lpFee | 12 bits protocolFee 1->0 | 12 bits protocolFee 0->1 | 24 bits tick | 160 bits sqrtPriceX96
- *
- * Fields in the direction from the least significant bit:
- *
- * The current price
- * uint160 sqrtPriceX96;
- *
- * The current tick
- * int24 tick;
- *
- * Protocol fee, expressed in hundredths of a bip, upper 12 bits are for 1->0, and the lower 12 are for 0->1
- * the maximum is 1000 - meaning the maximum protocol fee is 0.1%
- * the protocolFee is taken from the input first, then the lpFee is taken from the remaining input
- * uint24 protocolFee;
- *
- * The current LP fee of the pool. If the pool is dynamic, this does not include the dynamic fee flag.
- * uint24 lpFee;
- */
+/// @title Slot0
+/// @author Uniswap Labs
+/// @notice A packed representation of pool state variables stored in a single bytes32 slot
+/// @dev Slot0 is a packed version of a solidity structure, optimized for gas efficiency
+/// by storing multiple values in a single 32-byte storage slot.
+///
+/// Layout (256 bits total, from MSB to LSB):
+/// | 24 bits empty | 24 bits lpFee | 12 bits protocolFee 1->0 | 12 bits protocolFee 0->1 | 24 bits tick | 160 bits sqrtPriceX96 |
+///
+/// Fields (from least significant bit):
+/// - sqrtPriceX96 (160 bits): The current sqrt(price) as a Q64.96 value
+/// - tick (24 bits, signed): The current tick, representing log base 1.0001 of price
+/// - protocolFee (24 bits): Protocol fee in hundredths of a bip (max 1000 = 0.1%)
+///   - Lower 12 bits: fee for 0->1 swaps
+///   - Upper 12 bits: fee for 1->0 swaps
+/// - lpFee (24 bits): The LP fee of the pool (does not include dynamic fee flag)
+///
+/// Fee order: protocolFee is taken from input first, then lpFee from remaining
 type Slot0 is bytes32;
 
 using Slot0Library for Slot0 global;
 
-/// @notice Library for getting and setting values in the Slot0 type
+/// @title Slot0Library
+/// @author Uniswap Labs
+/// @notice Library for efficient bit manipulation of the packed Slot0 type
+/// @dev Provides gas-optimized getters and setters using inline assembly.
+/// All operations are pure and use memory-safe assembly patterns.
 library Slot0Library {
+    /// @dev Bitmask for extracting the 160-bit sqrtPriceX96 value (lowest 160 bits)
     uint160 internal constant MASK_160_BITS = 0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+
+    /// @dev Bitmask for extracting 24-bit values (tick, fees)
     uint24 internal constant MASK_24_BITS = 0xFFFFFF;
 
+    /// @dev Bit offset for the tick field (starts after sqrtPriceX96's 160 bits)
     uint8 internal constant TICK_OFFSET = 160;
+
+    /// @dev Bit offset for the protocol fee field (starts after tick's 24 bits)
     uint8 internal constant PROTOCOL_FEE_OFFSET = 184;
+
+    /// @dev Bit offset for the LP fee field (starts after protocolFee's 24 bits)
     uint8 internal constant LP_FEE_OFFSET = 208;
 
-    // #### GETTERS ####
+    // ╔═══════════════════════════════════════════════════════════════════════╗
+    // ║                              GETTERS                                   ║
+    // ╚═══════════════════════════════════════════════════════════════════════╝
+
+    /// @notice Extracts the sqrtPriceX96 value from the packed Slot0
+    /// @dev sqrtPriceX96 occupies the lowest 160 bits of Slot0.
+    /// Represents sqrt(price) * 2^96 in Q64.96 fixed-point format.
+    /// @param _packed The packed Slot0 value to extract from
+    /// @return _sqrtPriceX96 The current sqrt price as a Q64.96 value
     function sqrtPriceX96(Slot0 _packed) internal pure returns (uint160 _sqrtPriceX96) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Mask the lowest 160 bits to extract sqrtPriceX96
             _sqrtPriceX96 := and(MASK_160_BITS, _packed)
         }
     }
 
+    /// @notice Extracts the tick value from the packed Slot0
+    /// @dev tick occupies bits 160-183 (24 bits) of Slot0.
+    /// Uses signextend to properly handle negative tick values.
+    /// The tick represents the log base 1.0001 of the price.
+    /// @param _packed The packed Slot0 value to extract from
+    /// @return _tick The current tick (signed 24-bit integer)
     function tick(Slot0 _packed) internal pure returns (int24 _tick) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Shift right by TICK_OFFSET, then sign-extend from 3 bytes (24 bits)
+            // signextend(2, x) sign-extends x from byte index 2 (3 bytes)
             _tick := signextend(2, shr(TICK_OFFSET, _packed))
         }
     }
 
+    /// @notice Extracts the protocol fee value from the packed Slot0
+    /// @dev protocolFee occupies bits 184-207 (24 bits) of Slot0.
+    /// The fee is split: lower 12 bits for 0->1 direction, upper 12 bits for 1->0.
+    /// Fee is in hundredths of a bip (1e-6), max 1000 = 0.1%.
+    /// @param _packed The packed Slot0 value to extract from
+    /// @return _protocolFee The combined protocol fee (both directions)
     function protocolFee(Slot0 _packed) internal pure returns (uint24 _protocolFee) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Shift right to position protocolFee at LSB, then mask 24 bits
             _protocolFee := and(MASK_24_BITS, shr(PROTOCOL_FEE_OFFSET, _packed))
         }
     }
 
+    /// @notice Extracts the LP fee value from the packed Slot0
+    /// @dev lpFee occupies bits 208-231 (24 bits) of Slot0.
+    /// For dynamic fee pools, this value does NOT include the dynamic fee flag.
+    /// Fee is in hundredths of a bip (1e-6), so 3000 = 0.30%.
+    /// @param _packed The packed Slot0 value to extract from
+    /// @return _lpFee The current LP fee of the pool
     function lpFee(Slot0 _packed) internal pure returns (uint24 _lpFee) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Shift right to position lpFee at LSB, then mask 24 bits
             _lpFee := and(MASK_24_BITS, shr(LP_FEE_OFFSET, _packed))
         }
     }
 
-    // #### SETTERS ####
+    // ╔═══════════════════════════════════════════════════════════════════════╗
+    // ║                              SETTERS                                   ║
+    // ╚═══════════════════════════════════════════════════════════════════════╝
+
+    /// @notice Sets the sqrtPriceX96 value in the packed Slot0
+    /// @dev Clears the lowest 160 bits and sets the new value.
+    /// The new value is masked to ensure only 160 bits are used.
+    /// @param _packed The original packed Slot0 value
+    /// @param _sqrtPriceX96 The new sqrt price to set
+    /// @return _result The new Slot0 with updated sqrtPriceX96
     function setSqrtPriceX96(Slot0 _packed, uint160 _sqrtPriceX96) internal pure returns (Slot0 _result) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Clear lowest 160 bits of _packed, then OR with masked _sqrtPriceX96
             _result := or(and(not(MASK_160_BITS), _packed), and(MASK_160_BITS, _sqrtPriceX96))
         }
     }
 
+    /// @notice Sets the tick value in the packed Slot0
+    /// @dev Clears bits 160-183 and sets the new tick value.
+    /// The tick is masked to 24 bits before being shifted into position.
+    /// @param _packed The original packed Slot0 value
+    /// @param _tick The new tick value to set (will be truncated to 24 bits)
+    /// @return _result The new Slot0 with updated tick
     function setTick(Slot0 _packed, int24 _tick) internal pure returns (Slot0 _result) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Create mask at tick position, clear those bits, then OR with new value
             _result := or(and(not(shl(TICK_OFFSET, MASK_24_BITS)), _packed), shl(TICK_OFFSET, and(MASK_24_BITS, _tick)))
         }
     }
 
+    /// @notice Sets the protocol fee value in the packed Slot0
+    /// @dev Clears bits 184-207 and sets the new protocol fee.
+    /// Protocol fee format: lower 12 bits for 0->1, upper 12 bits for 1->0.
+    /// @param _packed The original packed Slot0 value
+    /// @param _protocolFee The new protocol fee to set (combined for both directions)
+    /// @return _result The new Slot0 with updated protocol fee
     function setProtocolFee(Slot0 _packed, uint24 _protocolFee) internal pure returns (Slot0 _result) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Create mask at protocol fee position, clear those bits, then OR with new value
             _result :=
                 or(
                     and(not(shl(PROTOCOL_FEE_OFFSET, MASK_24_BITS)), _packed),
@@ -85,8 +154,16 @@ library Slot0Library {
         }
     }
 
+    /// @notice Sets the LP fee value in the packed Slot0
+    /// @dev Clears bits 208-231 and sets the new LP fee.
+    /// For dynamic fee pools, this should not include the dynamic fee flag.
+    /// @param _packed The original packed Slot0 value
+    /// @param _lpFee The new LP fee to set
+    /// @return _result The new Slot0 with updated LP fee
     function setLpFee(Slot0 _packed, uint24 _lpFee) internal pure returns (Slot0 _result) {
+        /// @solidity memory-safe-assembly
         assembly ("memory-safe") {
+            // Create mask at LP fee position, clear those bits, then OR with new value
             _result :=
                 or(and(not(shl(LP_FEE_OFFSET, MASK_24_BITS)), _packed), shl(LP_FEE_OFFSET, and(MASK_24_BITS, _lpFee)))
         }

--- a/test/libraries/FixedPointLibraries.t.sol
+++ b/test/libraries/FixedPointLibraries.t.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {FixedPoint96} from "../../src/libraries/FixedPoint96.sol";
+import {FixedPoint128} from "../../src/libraries/FixedPoint128.sol";
+
+/// @notice Tests for FixedPoint96 and FixedPoint128 libraries
+/// @dev Validates the correctness of the fixed-point constants used throughout Uniswap v4
+contract FixedPointLibrariesTest is Test {
+    /// @notice Verifies that Q96 equals 2^96
+    function test_Q96_value() public pure {
+        assertEq(FixedPoint96.Q96, 2 ** 96);
+        assertEq(FixedPoint96.Q96, 79228162514264337593543950336);
+    }
+
+    /// @notice Verifies that Q128 equals 2^128
+    function test_Q128_value() public pure {
+        assertEq(FixedPoint128.Q128, 2 ** 128);
+        assertEq(FixedPoint128.Q128, 340282366920938463463374607431768211456);
+    }
+
+    /// @notice Verifies the RESOLUTION constant for Q96
+    function test_Q96_resolution() public pure {
+        assertEq(FixedPoint96.RESOLUTION, 96);
+        assertEq(FixedPoint96.Q96, 1 << FixedPoint96.RESOLUTION);
+    }
+
+    /// @notice Tests that Q96 and Q128 have the expected relationship
+    function test_Q96_Q128_relationship() public pure {
+        // Q128 should be Q96 * 2^32
+        assertEq(FixedPoint128.Q128, FixedPoint96.Q96 * (2 ** 32));
+    }
+
+    /// @notice Fuzz test for Q96 fixed-point multiplication and division
+    /// @dev Verifies that multiplying by Q96 then dividing returns the original value
+    function test_fuzz_Q96_roundtrip(uint160 value) public pure {
+        vm.assume(value > 0);
+        // Multiply by Q96 and divide should return original
+        uint256 scaled = uint256(value) * FixedPoint96.Q96;
+        uint256 result = scaled / FixedPoint96.Q96;
+        assertEq(result, value);
+    }
+
+    /// @notice Fuzz test for Q128 fixed-point multiplication and division
+    /// @dev Verifies that multiplying by Q128 then dividing returns the original value
+    function test_fuzz_Q128_roundtrip(uint128 value) public pure {
+        vm.assume(value > 0);
+        // Multiply by Q128 and divide should return original
+        uint256 scaled = uint256(value) * FixedPoint128.Q128;
+        uint256 result = scaled / FixedPoint128.Q128;
+        assertEq(result, value);
+    }
+
+    /// @notice Tests Q96 hex representation
+    function test_Q96_hex() public pure {
+        // Q96 in hex should be 0x1000000000000000000000000 (1 followed by 24 zeros)
+        assertEq(FixedPoint96.Q96, 0x1000000000000000000000000);
+    }
+
+    /// @notice Tests Q128 hex representation
+    function test_Q128_hex() public pure {
+        // Q128 in hex should be 0x100000000000000000000000000000000 (1 followed by 32 zeros)
+        assertEq(FixedPoint128.Q128, 0x100000000000000000000000000000000);
+    }
+
+    /// @notice Tests precision bounds for Q96
+    function test_Q96_precision_bounds() public pure {
+        // Q96 provides approximately 29 decimal digits of precision
+        // This test validates the precision range
+        uint256 maxPrecision = type(uint256).max / FixedPoint96.Q96;
+        assertTrue(maxPrecision > 0);
+        // Ensure Q96 doesn't overflow when used with uint160 (max sqrtPriceX96)
+        assertTrue(type(uint160).max < type(uint256).max / FixedPoint96.Q96);
+    }
+
+    /// @notice Tests precision bounds for Q128
+    function test_Q128_precision_bounds() public pure {
+        // Q128 is used for fee growth calculations
+        uint256 maxPrecision = type(uint256).max / FixedPoint128.Q128;
+        assertTrue(maxPrecision > 0);
+        // Ensure Q128 doesn't overflow when used with uint128 (max liquidity)
+        assertTrue(type(uint128).max == type(uint256).max / FixedPoint128.Q128);
+    }
+}


### PR DESCRIPTION
## Related Issue

N/A (Improves documentation quality and coverage across core libraries)

## Description of changes

This PR enhances the codebase documentation by adding comprehensive NatSpec comments to 14 core library and type files. It specifically focuses on clarifying low-level implementation details, bit manipulation logic, and assembly operations in the `libraries` and `types` directories.

**Detailed changes:**
- Added robust library-level documentation explaining the purpose, usage, and memory layout (where applicable) for each file.
- Documented over 50+ functions with `@notice`, `@dev`, `@param`, and `@return` tags.
- Enhanced developer comments for assembly blocks and bitwise operations to improve readability and maintainability.
- Added EIP-1153 transient storage explanations to [CurrencyReserves.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/CurrencyReserves.sol:0:0-0:0).
- Clarified memory layout for packed structs in [Slot0.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/types/Slot0.sol:0:0-0:0) and [PoolKey.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/types/PoolKey.sol:0:0-0:0).
- Documented `Currency` value type and associated library functions.

**Files improved:**
- `src/libraries/`: [BitMath.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/BitMath.sol:0:0-0:0), [CurrencyReserves.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/CurrencyReserves.sol:0:0-0:0), [FixedPoint96.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/FixedPoint96.sol:0:0-0:0), [FixedPoint128.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/FixedPoint128.sol:0:0-0:0), [LiquidityMath.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/LiquidityMath.sol:0:0-0:0), [Lock.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/Lock.sol:0:0-0:0), [ParseBytes.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/ParseBytes.sol:0:0-0:0), [SafeCast.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/SafeCast.sol:0:0-0:0), [UnsafeMath.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/UnsafeMath.sol:0:0-0:0), [NonzeroDeltaCount.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/NonzeroDeltaCount.sol:0:0-0:0), [CurrencyDelta.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/libraries/CurrencyDelta.sol:0:0-0:0)
- `src/types/`: [BalanceDelta.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/types/BalanceDelta.sol:0:0-0:0), [BeforeSwapDelta.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/types/BeforeSwapDelta.sol:0:0-0:0), [PoolId.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/types/PoolId.sol:0:0-0:0), [Currency.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/types/Currency.sol:0:0-0:0), [Slot0.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/types/Slot0.sol:0:0-0:0), [PoolOperation.sol](cci:7://file:///f:/Github%20contributation/v4-core/src/types/PoolOperation.sol:0:0-0:0)
- `test/`: Added `FixedPointLibraries.t.sol` for coverage.