### PR TITLE
test: add comprehensive tests for ParseBytes, CustomRevert, CurrencyD…

### DIFF
--- a/test/libraries/CurrencyDelta.t.sol
+++ b/test/libraries/CurrencyDelta.t.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {CurrencyDelta} from "../../src/libraries/CurrencyDelta.sol";
+import {Currency} from "../../src/types/Currency.sol";
+
+/// @notice Harness that exposes CurrencyDelta internal functions
+contract CurrencyDeltaHarness {
+    function getDelta(Currency currency, address target) external view returns (int256) {
+        return CurrencyDelta.getDelta(currency, target);
+    }
+
+    function applyDelta(Currency currency, address target, int128 delta)
+        external
+        returns (int256 previous, int256 next)
+    {
+        return CurrencyDelta.applyDelta(currency, target, delta);
+    }
+
+    function computeSlot(address target, Currency currency) external pure returns (bytes32) {
+        return CurrencyDelta._computeSlot(target, currency);
+    }
+}
+
+contract CurrencyDeltaTest is Test {
+    CurrencyDeltaHarness harness;
+
+    Currency currency0;
+    Currency currency1;
+    address alice;
+    address bob;
+
+    function setUp() public {
+        harness = new CurrencyDeltaHarness();
+        currency0 = Currency.wrap(address(0x1111));
+        currency1 = Currency.wrap(address(0x2222));
+        alice = address(0xA11CE);
+        bob = address(0xB0B);
+    }
+
+    function test_getDelta_defaultsToZero() public view {
+        assertEq(harness.getDelta(currency0, alice), 0);
+    }
+
+    function test_applyDelta_positiveDelta() public {
+        (int256 prev, int256 next) = harness.applyDelta(currency0, alice, 100);
+        assertEq(prev, 0);
+        assertEq(next, 100);
+        assertEq(harness.getDelta(currency0, alice), 100);
+    }
+
+    function test_applyDelta_negativeDelta() public {
+        (int256 prev, int256 next) = harness.applyDelta(currency0, alice, -50);
+        assertEq(prev, 0);
+        assertEq(next, -50);
+        assertEq(harness.getDelta(currency0, alice), -50);
+    }
+
+    function test_applyDelta_accumulates() public {
+        harness.applyDelta(currency0, alice, 100);
+        (int256 prev, int256 next) = harness.applyDelta(currency0, alice, 200);
+        assertEq(prev, 100);
+        assertEq(next, 300);
+    }
+
+    function test_applyDelta_netToZero() public {
+        harness.applyDelta(currency0, alice, 100);
+        (int256 prev, int256 next) = harness.applyDelta(currency0, alice, -100);
+        assertEq(prev, 100);
+        assertEq(next, 0);
+        assertEq(harness.getDelta(currency0, alice), 0);
+    }
+
+    function test_differentCurrencies_isolated() public {
+        harness.applyDelta(currency0, alice, 100);
+        harness.applyDelta(currency1, alice, -50);
+        assertEq(harness.getDelta(currency0, alice), 100);
+        assertEq(harness.getDelta(currency1, alice), -50);
+    }
+
+    function test_differentAddresses_isolated() public {
+        harness.applyDelta(currency0, alice, 100);
+        harness.applyDelta(currency0, bob, -200);
+        assertEq(harness.getDelta(currency0, alice), 100);
+        assertEq(harness.getDelta(currency0, bob), -200);
+    }
+
+    function test_computeSlot_deterministic() public view {
+        bytes32 slot1 = harness.computeSlot(alice, currency0);
+        bytes32 slot2 = harness.computeSlot(alice, currency0);
+        assertEq(slot1, slot2);
+    }
+
+    function test_computeSlot_uniquePerPair() public view {
+        bytes32 slot1 = harness.computeSlot(alice, currency0);
+        bytes32 slot2 = harness.computeSlot(alice, currency1);
+        bytes32 slot3 = harness.computeSlot(bob, currency0);
+        assertTrue(slot1 != slot2);
+        assertTrue(slot1 != slot3);
+        assertTrue(slot2 != slot3);
+    }
+
+    function test_computeSlot_matchesExpected() public view {
+        bytes32 expected = keccak256(abi.encode(uint256(uint160(alice)), uint256(uint160(Currency.unwrap(currency0)))));
+        bytes32 actual = harness.computeSlot(alice, currency0);
+        assertEq(actual, expected);
+    }
+
+    function test_fuzz_applyDelta(int128 delta1, int128 delta2) public {
+        // Avoid overflow: ensure delta1 + delta2 doesn't overflow int256
+        int256 sum = int256(delta1) + int256(delta2);
+
+        (int256 prev1, int256 next1) = harness.applyDelta(currency0, alice, delta1);
+        assertEq(prev1, 0);
+        assertEq(next1, int256(delta1));
+
+        (int256 prev2, int256 next2) = harness.applyDelta(currency0, alice, delta2);
+        assertEq(prev2, int256(delta1));
+        assertEq(next2, sum);
+    }
+
+    function test_applyDelta_maxInt128() public {
+        int128 maxVal = type(int128).max;
+        (int256 prev, int256 next) = harness.applyDelta(currency0, alice, maxVal);
+        assertEq(prev, 0);
+        assertEq(next, int256(maxVal));
+    }
+
+    function test_applyDelta_minInt128() public {
+        int128 minVal = type(int128).min;
+        (int256 prev, int256 next) = harness.applyDelta(currency0, alice, minVal);
+        assertEq(prev, 0);
+        assertEq(next, int256(minVal));
+    }
+}

--- a/test/libraries/CurrencyReserves.t.sol
+++ b/test/libraries/CurrencyReserves.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {CurrencyReserves} from "../../src/libraries/CurrencyReserves.sol";
+import {Currency} from "../../src/types/Currency.sol";
+
+/// @notice Harness that exposes CurrencyReserves internal functions
+contract CurrencyReservesHarness {
+    function getSyncedCurrency() external view returns (Currency) {
+        return CurrencyReserves.getSyncedCurrency();
+    }
+
+    function resetCurrency() external {
+        CurrencyReserves.resetCurrency();
+    }
+
+    function syncCurrencyAndReserves(Currency currency, uint256 value) external {
+        CurrencyReserves.syncCurrencyAndReserves(currency, value);
+    }
+
+    function getSyncedReserves() external view returns (uint256) {
+        return CurrencyReserves.getSyncedReserves();
+    }
+}
+
+contract CurrencyReservesTest is Test {
+    CurrencyReservesHarness harness;
+
+    function setUp() public {
+        harness = new CurrencyReservesHarness();
+    }
+
+    function test_initialCurrencyIsZero() public view {
+        Currency currency = harness.getSyncedCurrency();
+        assertTrue(Currency.unwrap(currency) == address(0));
+    }
+
+    function test_initialReservesAreZero() public view {
+        assertEq(harness.getSyncedReserves(), 0);
+    }
+
+    function test_syncCurrencyAndReserves() public {
+        Currency currency = Currency.wrap(address(0xBEEF));
+        uint256 reserves = 1000 ether;
+
+        harness.syncCurrencyAndReserves(currency, reserves);
+
+        assertEq(Currency.unwrap(harness.getSyncedCurrency()), address(0xBEEF));
+        assertEq(harness.getSyncedReserves(), reserves);
+    }
+
+    function test_resetCurrency_clearsOnlyCurrency() public {
+        Currency currency = Currency.wrap(address(0xBEEF));
+        harness.syncCurrencyAndReserves(currency, 500);
+
+        harness.resetCurrency();
+
+        assertTrue(Currency.unwrap(harness.getSyncedCurrency()) == address(0));
+        // Reserves remain after reset (only currency is cleared)
+        assertEq(harness.getSyncedReserves(), 500);
+    }
+
+    function test_syncOverwritesPrevious() public {
+        harness.syncCurrencyAndReserves(Currency.wrap(address(0x1)), 100);
+        harness.syncCurrencyAndReserves(Currency.wrap(address(0x2)), 200);
+
+        assertEq(Currency.unwrap(harness.getSyncedCurrency()), address(0x2));
+        assertEq(harness.getSyncedReserves(), 200);
+    }
+
+    function test_fuzz_syncCurrencyAndReserves(address currencyAddr, uint256 reserves) public {
+        Currency currency = Currency.wrap(currencyAddr);
+        harness.syncCurrencyAndReserves(currency, reserves);
+
+        assertEq(Currency.unwrap(harness.getSyncedCurrency()), currencyAddr);
+        assertEq(harness.getSyncedReserves(), reserves);
+    }
+
+    function test_syncWithZeroReserves() public {
+        Currency currency = Currency.wrap(address(0xCAFE));
+        harness.syncCurrencyAndReserves(currency, 0);
+
+        assertEq(Currency.unwrap(harness.getSyncedCurrency()), address(0xCAFE));
+        assertEq(harness.getSyncedReserves(), 0);
+    }
+
+    function test_syncWithMaxReserves() public {
+        Currency currency = Currency.wrap(address(0xDEAD));
+        harness.syncCurrencyAndReserves(currency, type(uint256).max);
+
+        assertEq(Currency.unwrap(harness.getSyncedCurrency()), address(0xDEAD));
+        assertEq(harness.getSyncedReserves(), type(uint256).max);
+    }
+
+    function test_slotsAreCorrect() public pure {
+        // Verify the slot constants match their documented derivation
+        assertEq(
+            CurrencyReserves.RESERVES_OF_SLOT,
+            bytes32(uint256(keccak256("ReservesOf")) - 1)
+        );
+        assertEq(
+            CurrencyReserves.CURRENCY_SLOT,
+            bytes32(uint256(keccak256("Currency")) - 1)
+        );
+    }
+}

--- a/test/libraries/CustomRevert.t.sol
+++ b/test/libraries/CustomRevert.t.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {CustomRevert} from "../../src/libraries/CustomRevert.sol";
+
+/// @notice Harness contract to expose internal CustomRevert functions for testing
+contract CustomRevertHarness {
+    using CustomRevert for bytes4;
+
+    error SimpleError();
+    error AddressError(address);
+    error Int24Error(int24);
+    error Uint160Error(uint160);
+    error TwoInt24Error(int24, int24);
+    error TwoUint160Error(uint160, uint160);
+    error TwoAddressError(address, address);
+
+    function revertWithNoArgs() external pure {
+        SimpleError.selector.revertWith();
+    }
+
+    function revertWithAddress(address addr) external pure {
+        AddressError.selector.revertWith(addr);
+    }
+
+    function revertWithInt24(int24 value) external pure {
+        Int24Error.selector.revertWith(value);
+    }
+
+    function revertWithUint160(uint160 value) external pure {
+        Uint160Error.selector.revertWith(value);
+    }
+
+    function revertWithTwoInt24(int24 value1, int24 value2) external pure {
+        TwoInt24Error.selector.revertWith(value1, value2);
+    }
+
+    function revertWithTwoUint160(uint160 value1, uint160 value2) external pure {
+        TwoUint160Error.selector.revertWith(value1, value2);
+    }
+
+    function revertWithTwoAddresses(address addr1, address addr2) external pure {
+        TwoAddressError.selector.revertWith(addr1, addr2);
+    }
+
+    function callAndBubbleUp(address target, bytes calldata data, bytes4 additionalContext) external view {
+        (bool success,) = target.staticcall(data);
+        if (!success) {
+            CustomRevert.bubbleUpAndRevertWith(target, bytes4(data[:4]), additionalContext);
+        }
+    }
+}
+
+/// @notice Helper contract that always reverts
+contract AlwaysReverts {
+    error InnerError(uint256 value);
+
+    function failWithInnerError(uint256 val) external pure {
+        revert InnerError(val);
+    }
+}
+
+contract CustomRevertTest is Test {
+    CustomRevertHarness harness;
+    AlwaysReverts reverter;
+
+    function setUp() public {
+        harness = new CustomRevertHarness();
+        reverter = new AlwaysReverts();
+    }
+
+    function test_revertWith_noArgs() public {
+        vm.expectRevert(CustomRevertHarness.SimpleError.selector);
+        harness.revertWithNoArgs();
+    }
+
+    function test_revertWith_address() public {
+        address addr = address(0xBEEF);
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.AddressError.selector, addr));
+        harness.revertWithAddress(addr);
+    }
+
+    function test_revertWith_addressZero() public {
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.AddressError.selector, address(0)));
+        harness.revertWithAddress(address(0));
+    }
+
+    function test_fuzz_revertWith_address(address addr) public {
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.AddressError.selector, addr));
+        harness.revertWithAddress(addr);
+    }
+
+    function test_revertWith_int24_positive() public {
+        int24 val = 8388607; // max int24
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.Int24Error.selector, val));
+        harness.revertWithInt24(val);
+    }
+
+    function test_revertWith_int24_negative() public {
+        int24 val = -8388608; // min int24
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.Int24Error.selector, val));
+        harness.revertWithInt24(val);
+    }
+
+    function test_revertWith_int24_zero() public {
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.Int24Error.selector, int24(0)));
+        harness.revertWithInt24(int24(0));
+    }
+
+    function test_fuzz_revertWith_int24(int24 value) public {
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.Int24Error.selector, value));
+        harness.revertWithInt24(value);
+    }
+
+    function test_revertWith_uint160() public {
+        uint160 val = type(uint160).max;
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.Uint160Error.selector, val));
+        harness.revertWithUint160(val);
+    }
+
+    function test_fuzz_revertWith_uint160(uint160 value) public {
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.Uint160Error.selector, value));
+        harness.revertWithUint160(value);
+    }
+
+    function test_revertWith_twoInt24() public {
+        int24 v1 = 100;
+        int24 v2 = -200;
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.TwoInt24Error.selector, v1, v2));
+        harness.revertWithTwoInt24(v1, v2);
+    }
+
+    function test_fuzz_revertWith_twoInt24(int24 v1, int24 v2) public {
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.TwoInt24Error.selector, v1, v2));
+        harness.revertWithTwoInt24(v1, v2);
+    }
+
+    function test_revertWith_twoUint160() public {
+        uint160 v1 = 1;
+        uint160 v2 = type(uint160).max;
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.TwoUint160Error.selector, v1, v2));
+        harness.revertWithTwoUint160(v1, v2);
+    }
+
+    function test_fuzz_revertWith_twoUint160(uint160 v1, uint160 v2) public {
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.TwoUint160Error.selector, v1, v2));
+        harness.revertWithTwoUint160(v1, v2);
+    }
+
+    function test_revertWith_twoAddresses() public {
+        address a1 = address(0x1);
+        address a2 = address(0x2);
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.TwoAddressError.selector, a1, a2));
+        harness.revertWithTwoAddresses(a1, a2);
+    }
+
+    function test_fuzz_revertWith_twoAddresses(address a1, address a2) public {
+        vm.expectRevert(abi.encodeWithSelector(CustomRevertHarness.TwoAddressError.selector, a1, a2));
+        harness.revertWithTwoAddresses(a1, a2);
+    }
+
+    function test_bubbleUpAndRevertWith() public {
+        bytes memory callData = abi.encodeWithSelector(AlwaysReverts.failWithInnerError.selector, uint256(42));
+        bytes4 context = bytes4(0xffffffff);
+
+        vm.expectRevert();
+        harness.callAndBubbleUp(address(reverter), callData, context);
+    }
+
+    function test_bubbleUpAndRevertWith_encodesWrappedError() public {
+        bytes memory innerCallData = abi.encodeWithSelector(AlwaysReverts.failWithInnerError.selector, uint256(42));
+        bytes4 context = bytes4(0xaabbccdd);
+
+        // Get the inner revert data
+        (bool success, bytes memory innerRevertData) =
+            address(reverter).staticcall(innerCallData);
+        assertFalse(success);
+
+        // Expect WrappedError with correct parameters
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CustomRevert.WrappedError.selector,
+                address(reverter),
+                AlwaysReverts.failWithInnerError.selector,
+                innerRevertData,
+                abi.encodePacked(context)
+            )
+        );
+        harness.callAndBubbleUp(address(reverter), innerCallData, context);
+    }
+}

--- a/test/libraries/ParseBytes.t.sol
+++ b/test/libraries/ParseBytes.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ParseBytes} from "../../src/libraries/ParseBytes.sol";
+
+contract ParseBytesTest is Test {
+    using ParseBytes for bytes;
+
+    function test_parseSelector_returnsFirstFourBytes() public pure {
+        bytes4 expectedSelector = bytes4(keccak256("someFunction(uint256)"));
+        bytes memory data = abi.encode(expectedSelector, int256(0));
+        assertEq(ParseBytes.parseSelector(data), expectedSelector);
+    }
+
+    function test_parseSelector_withNonZeroDelta() public pure {
+        bytes4 expectedSelector = bytes4(0xdeadbeef);
+        bytes memory data = abi.encode(expectedSelector, int256(12345));
+        assertEq(ParseBytes.parseSelector(data), expectedSelector);
+    }
+
+    function test_fuzz_parseSelector(bytes4 selector, int256 delta) public pure {
+        bytes memory data = abi.encode(selector, delta);
+        assertEq(ParseBytes.parseSelector(data), selector);
+    }
+
+    function test_parseReturnDelta_returnsSecondWord() public pure {
+        bytes4 selector = bytes4(0x12345678);
+        int256 expectedDelta = -999;
+        bytes memory data = abi.encode(selector, expectedDelta);
+        assertEq(ParseBytes.parseReturnDelta(data), expectedDelta);
+    }
+
+    function test_parseReturnDelta_zero() public pure {
+        bytes memory data = abi.encode(bytes4(0xaabbccdd), int256(0));
+        assertEq(ParseBytes.parseReturnDelta(data), 0);
+    }
+
+    function test_parseReturnDelta_maxPositive() public pure {
+        bytes memory data = abi.encode(bytes4(0x00000000), type(int256).max);
+        assertEq(ParseBytes.parseReturnDelta(data), type(int256).max);
+    }
+
+    function test_parseReturnDelta_minNegative() public pure {
+        bytes memory data = abi.encode(bytes4(0x00000000), type(int256).min);
+        assertEq(ParseBytes.parseReturnDelta(data), type(int256).min);
+    }
+
+    function test_fuzz_parseReturnDelta(bytes4 selector, int256 delta) public pure {
+        bytes memory data = abi.encode(selector, delta);
+        assertEq(ParseBytes.parseReturnDelta(data), delta);
+    }
+
+    function test_parseFee_returnsThirdWord() public pure {
+        bytes4 selector = bytes4(0x12345678);
+        int256 delta = 100;
+        uint24 expectedFee = 3000;
+        bytes memory data = abi.encode(selector, delta, expectedFee);
+        assertEq(ParseBytes.parseFee(data), expectedFee);
+    }
+
+    function test_parseFee_maxFee() public pure {
+        uint24 maxFee = type(uint24).max; // 16777215
+        bytes memory data = abi.encode(bytes4(0x00000000), int256(0), maxFee);
+        assertEq(ParseBytes.parseFee(data), maxFee);
+    }
+
+    function test_parseFee_zeroFee() public pure {
+        bytes memory data = abi.encode(bytes4(0x00000000), int256(0), uint24(0));
+        assertEq(ParseBytes.parseFee(data), 0);
+    }
+
+    function test_fuzz_parseFee(bytes4 selector, int256 delta, uint24 fee) public pure {
+        bytes memory data = abi.encode(selector, delta, fee);
+        assertEq(ParseBytes.parseFee(data), fee);
+    }
+
+    function test_parseSelector_and_parseReturnDelta_consistent() public pure {
+        bytes4 selector = bytes4(0xaabbccdd);
+        int256 delta = -42;
+        bytes memory data = abi.encode(selector, delta);
+        assertEq(ParseBytes.parseSelector(data), selector);
+        assertEq(ParseBytes.parseReturnDelta(data), delta);
+    }
+
+    function test_allThreeFields_consistent() public pure {
+        bytes4 selector = bytes4(0x11223344);
+        int256 delta = 500;
+        uint24 fee = 10000;
+        bytes memory data = abi.encode(selector, delta, fee);
+        assertEq(ParseBytes.parseSelector(data), selector);
+        assertEq(ParseBytes.parseReturnDelta(data), delta);
+        assertEq(ParseBytes.parseFee(data), fee);
+    }
+
+    function test_fuzz_allThreeFields(bytes4 selector, int256 delta, uint24 fee) public pure {
+        bytes memory data = abi.encode(selector, delta, fee);
+        assertEq(ParseBytes.parseSelector(data), selector);
+        assertEq(ParseBytes.parseReturnDelta(data), delta);
+        assertEq(ParseBytes.parseFee(data), fee);
+    }
+}


### PR DESCRIPTION
…elta, and CurrencyReserves libraries

Add test suites for four previously untested libraries:

- ParseBytes: 15 tests covering parseSelector, parseReturnDelta, parseFee with boundary values and fuzz tests for all three functions
- CustomRevert: 18 tests covering all revertWith overloads (no-args, address, int24, uint160, two-arg variants) and bubbleUpAndRevertWith with ERC-7751 WrappedError encoding verification
- CurrencyDelta: 13 tests covering getDelta defaults, applyDelta accumulation, net-to-zero, currency/address isolation, slot determinism, and boundary values
- CurrencyReserves: 9 tests covering sync/reset lifecycle, slot constant verification, overwrite behavior, and boundary values

All tests include fuzz testing for robustness.

## Related Issue

Which issue does this pull request resolve?

## Description of changes
