### PR TITLE
fix: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/tests-merge.yml
+++ b/.github/workflows/tests-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
 
-      - uses: actions/checkout@v5 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary

Pin all GitHub Actions references from mutable tags to immutable commit SHAs to mitigate supply chain attacks. Mutable tags can be force-pushed by upstream maintainers (or attackers who compromise their accounts), allowing arbitrary code execution in CI. This is the same class of attack vector exploited in the [axios/axios-dev supply chain incident](https://blog.phylum.io/axios-lottie-player-and-more-npm-supply-chain-attacks/).

## What changed

- **`.github/workflows/tests-merge.yml`**: Pinned `actions/checkout@v5` to commit SHA `93cb6efe18208431cddfb8368fd83d5badbf9bfd`. All other actions in v4-core workflows (lint.yml, mythx.yml, tests-pr.yml) were already SHA-pinned.

## Test plan

- [x] Verified resolved SHAs via `gh api repos/{owner}/{repo}/git/ref/tags/{tag}`
- [x] Confirmed no tag objects needed dereferencing (all resolved directly to commits)
- [ ] CI should pass with pinned SHAs (functionally identical to tag references)

## Session context

Audited all 4 workflow files in `.github/workflows/`. Only `tests-merge.yml` had a remaining unpinned tag reference (`@v5`). The other 3 files were already fully SHA-pinned from a prior hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>