### PR TITLE
fix(comment): drop duplicate 'in' in Pool.SwapStepState NatSpec

### DIFF
--- a/src/libraries/Pool.sol
+++ b/src/libraries/Pool.sol
@@ -256,7 +256,7 @@ library Pool {
         bool initialized;
         // sqrt(price) for the next tick (1/0)
         uint160 sqrtPriceNextX96;
-        // how much is being swapped in in this step
+        // how much is being swapped in this step
         uint256 amountIn;
         // how much is being swapped out
         uint256 amountOut;


### PR DESCRIPTION
### What

Single-character comment fix in `src/libraries/Pool.sol`.

The inline NatSpec for the `amountIn` field of the `SwapStepState` struct reads:

```solidity
// how much is being swapped in in this step
uint256 amountIn;
```

The duplicated `in` is a typo. The neighbouring `amountOut` field two lines below uses the parallel form `// how much is being swapped out`, so the corrected comment is `// how much is being swapped in this step` — matching the surrounding style.

### Why

- Pure comment fix; no functional, ABI, storage-layout, or bytecode change.
- `Pool.sol` is one of the most-read files in v4-core (it implements the swap inner loop) so a small NatSpec/comment cleanup helps readers following the swap math.
- No tests need to change; `forge build` and `forge test` are unaffected.

### Notes

- One commit, GPG-signed.
- I deliberately did not run `forge fmt` against the file because it produces unrelated formatting churn elsewhere in `Pool.sol` (lines around `step.feeGrowthGlobalX128 += ...`) that pre-existed this branch — happy to add a separate PR for that if maintainers want.