### PR TITLE
docs: fix and clarify natspec inconsistencies

### DIFF
--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -52,7 +52,7 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
     /// @param id The abi encoded hash of the pool key struct for the new pool
     /// @param currency0 The first currency of the pool by address sort order
     /// @param currency1 The second currency of the pool by address sort order
-    /// @param fee The fee collected upon every swap in the pool, denominated in hundredths of a bip
+    /// @param fee The fee collected upon every swap in the pool, denominated in hundredths of a bip, or DYNAMIC_FEE_FLAG if the fee is dynamically set by the hook
     /// @param tickSpacing The minimum number of ticks between initialized ticks
     /// @param hooks The hooks contract address for the pool, or address(0) if none
     /// @param sqrtPriceX96 The price of the pool on initialization
@@ -108,7 +108,7 @@ interface IPoolManager is IProtocolFees, IERC6909Claims, IExtsload, IExttload {
 
     /// @notice All interactions on the contract that account deltas require unlocking. A caller that calls `unlock` must implement
     /// `IUnlockCallback(msg.sender).unlockCallback(data)`, where they interact with the remaining functions on this contract.
-    /// @dev The only functions callable without an unlocking are `initialize` and `updateDynamicLPFee`
+    /// @dev The only functions callable without an unlocking are `initialize`, `updateDynamicLPFee` and `sync`
     /// @param data Any data to pass to the callback, via `IUnlockCallback(msg.sender).unlockCallback(data)`
     /// @return The data returned by the call to `IUnlockCallback(msg.sender).unlockCallback(data)`
     function unlock(bytes calldata data) external returns (bytes memory);

--- a/src/interfaces/IProtocolFees.sol
+++ b/src/interfaces/IProtocolFees.sol
@@ -37,7 +37,6 @@ interface IProtocolFees {
     function setProtocolFeeController(address controller) external;
 
     /// @notice Collects the protocol fees for a given recipient and currency, returning the amount collected
-    /// @dev This will revert if the contract is unlocked
     /// @param recipient The address to receive the protocol fees
     /// @param currency The currency to withdraw
     /// @param amount The amount of currency to withdraw


### PR DESCRIPTION
## Related Issue

https://github.com/Uniswap/v4-core/issues/1070

## Description of changes

Fix and clarify natspec inconsistencies.
Below is the list of identified inconsistencies and proposed clarifications:

| File / Location | Current NatSpec | Proposed NatSpec | Rationale |
| :--- | :--- | :--- | :--- |
| [src/interfaces/IProtocolFees.sol#L40](https://github.com/Uniswap/v4-core/blob/main/src/interfaces/IProtocolFees.sol#L40) | This will revert if the contract is unlocked | Remove this comment | The collectProtocolFees function does not contain any check regarding the state of the pool (locked or unlocked). |
| [src/interfaces/IPoolManager.sol#L111](https://github.com/Uniswap/v4-core/blob/main/src/interfaces/IPoolManager.sol#L111 ) | The only functions callable without an unlocking are `initialize` and `updateDynamicLPFee` | The only functions callable without an unlocking are `initialize`, `updateDynamicLPFee` and `sync` | Function `sync()` also callable without unlocking. |
| [src/interfaces/IPoolManager.sol#55](https://github.com/Uniswap/v4-core/blob/main/src/interfaces/IPoolManager.sol#L55) | The fee collected upon every swap in the pool, denominated in hundredths of a bip | The fee collected upon every swap in the pool, denominated in hundredths of a bip, or DYNAMIC_FEE_FLAG if the fee is dynamically set by the hook | When a pool uses dynamic fees, the fee parameter in the Initialize event contains the value from the DYNAMIC_FEE_FLAG constant  |
