### PR TITLE
docs: point README imports at v4-core/src

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ To integrate with the contracts, the interfaces are available to use:
 
 ```solidity
 
-import {IPoolManager} from 'v4-core/contracts/interfaces/IPoolManager.sol';
-import {IUnlockCallback} from 'v4-core/contracts/interfaces/callback/IUnlockCallback.sol';
+import {IPoolManager} from 'v4-core/src/interfaces/IPoolManager.sol';
+import {IUnlockCallback} from 'v4-core/src/interfaces/callback/IUnlockCallback.sol';
 
 contract MyContract is IUnlockCallback {
     IPoolManager poolManager;


### PR DESCRIPTION
## Summary
README local-usage Solidity imports still used `v4-core/contracts/...`, but on tip the tree (and published package) live under `src/`. `contracts/` is gone (Contents API 404).

## Repro
```bash
TIP=46c6834698c48bc4a463a86d8420f4eb1d7f3b75
curl -sI https://raw.githubusercontent.com/Uniswap/v4-core/$TIP/src/interfaces/IPoolManager.sol | head -1   # 200
curl -sI https://raw.githubusercontent.com/Uniswap/v4-core/$TIP/contracts/interfaces/IPoolManager.sol | head -1  # 404
```

## Change
Update the two example imports in `README.md` from `contracts/` → `src/`.

## Notes
Open README rewrites #1020/#1016 do not fix these import paths.
